### PR TITLE
Reup-74 Apply check for index out of bounds

### DIFF
--- a/Editor/MaterialSelectorTriggerEditor.cs
+++ b/Editor/MaterialSelectorTriggerEditor.cs
@@ -1,23 +1,22 @@
-using System;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using ReupVirtualTwin.models;
-using ReupVirtualTwin.helpers;
-
 
 [CustomEditor(typeof(MaterialSelectionTrigger))]
 public class MaterialSelectorTriggerEditor : Editor
 {
+    MaterialSelectionTrigger trigger;
+
     public override void OnInspectorGUI()
     {
         DrawDefaultInspector();
-        MaterialSelectionTrigger trigger = (MaterialSelectionTrigger)target;
+        trigger = (MaterialSelectionTrigger)target;
 
         if (trigger.materialObjects.Count != 0)
         {
-            if (trigger.materialIndexes.Length != trigger.materialObjects.Count)
-                trigger.materialIndexes = new int[trigger.materialObjects.Count];
+            if (trigger.objectsMaterialIndexes.Length != trigger.materialObjects.Count)
+                trigger.objectsMaterialIndexes = new int[trigger.materialObjects.Count];
             EditorGUI.BeginChangeCheck();
             foreach (var (obj, j) in trigger.materialObjects.Select((v, i) => (v, i)))
             {
@@ -26,20 +25,32 @@ public class MaterialSelectorTriggerEditor : Editor
                     var materials = obj.GetComponent<Renderer>().sharedMaterials;
                     if (materials.Length > 1)
                     {
-                        EditorGUILayout.HelpBox($"The object '{obj.name}' has more than one material assigned, select the material you want to change", MessageType.Warning, true);
+                        var warningMessage = $"The object '{obj.name}' has more than one material assigned, select the material you want to change";
+                        EditorGUILayout.HelpBox(warningMessage, MessageType.Warning, true);
                         string[] materialOptions = new string[materials.Length];
                         for (int i = 0; i < materialOptions.Length; i++)
                         {
                             materialOptions[i] = materials[i].name;
                         }
-                        trigger.materialIndexes[j] = EditorGUILayout.Popup($"Material to change for {obj.name}", trigger.materialIndexes[j], materialOptions);
+                        var infoMessage = $"Material to change for {obj.name}";
+                        trigger.objectsMaterialIndexes[j] = EditorGUILayout.Popup(infoMessage,
+                                                                                  trigger.objectsMaterialIndexes[j],
+                                                                                  materialOptions);
                     }
+                    checkIndexOutOfMaterialsArray(j, materials);
                 }
             }
             if (EditorGUI.EndChangeCheck())
             {
                 EditorUtility.SetDirty(trigger);
             }
+        }
+    }
+    private void checkIndexOutOfMaterialsArray(int index, Material[] materials)
+    {
+        if (trigger.objectsMaterialIndexes[index] >= materials.Length)
+        {
+            trigger.objectsMaterialIndexes[index] = 0;
         }
     }
 }

--- a/Runtime/Behaviours/Select/ClickMaterialSelection.cs
+++ b/Runtime/Behaviours/Select/ClickMaterialSelection.cs
@@ -15,7 +15,6 @@ namespace ReupVirtualTwin
         }
         public override void HandleObject(GameObject materialSelectionObject)
         {
-            //Debug.Log("you clicked the material Selection object " + materialSelectionObject);
             var material = materialSelectionObject.GetComponent<Renderer>().material;
             _materialsManager.SetNewMaterial(material);
         }
@@ -23,7 +22,6 @@ namespace ReupVirtualTwin
         {
             if (!_dragManager.dragging && !_dragManager.prevDragging)
             {
-                //Debug.Log("Miss material selection, so hiding materials");
                 _materialContainerCreator.HideContainer();
             }
         }

--- a/Runtime/Behaviours/Select/ClickSceneTrigger.cs
+++ b/Runtime/Behaviours/Select/ClickSceneTrigger.cs
@@ -17,7 +17,7 @@ namespace ReupVirtualTwin
         public override void HandleObject(GameObject triggerObject)
         {
             var materialSelectionTrigger = triggerObject.GetComponent<MaterialSelectionTrigger>();
-            _materialsManager.SelectObjects(materialSelectionTrigger.materialObjects, materialSelectionTrigger.materialIndexes);
+            _materialsManager.SelectObjects(materialSelectionTrigger.materialObjects, materialSelectionTrigger.objectsMaterialIndexes);
             _containerCreator.CreateContainer(materialSelectionTrigger.selectableMaterials.ToArray());
         }
     }

--- a/Runtime/Managers/MaterialsManager.cs
+++ b/Runtime/Managers/MaterialsManager.cs
@@ -8,10 +8,10 @@ public class MaterialsManager : MonoBehaviour
     private int[] selectedMaterialIndexes;
 
 
-    public void SelectObjects(List<GameObject> objs, int[] materialIndexes)
+    public void SelectObjects(List<GameObject> objs, int[] objectsMaterialIndexes)
     {
         selectedObjects = objs;
-        selectedMaterialIndexes = materialIndexes;
+        selectedMaterialIndexes = objectsMaterialIndexes;
     }
 
     public void SetNewMaterial(Material material)

--- a/Runtime/Models/MaterialSelectionTrigger.cs
+++ b/Runtime/Models/MaterialSelectionTrigger.cs
@@ -8,7 +8,7 @@ namespace ReupVirtualTwin.models
     {
         public List<GameObject> materialObjects;
         [HideInInspector]
-        public int[] materialIndexes;
+        public int[] objectsMaterialIndexes;
         public List<Material> selectableMaterials;
     }
 }


### PR DESCRIPTION
[Reup-74](https://macheight-reup.atlassian.net/browse/REUP-74?atlOrigin=eyJpIjoiMzA5ZTEwZmY2YzE0NDhjOTljMTg0NmNhZjcwM2I1YjIiLCJwIjoiaiJ9)

As a developer, I want to ensure that when a user selects an object with fewer sub-meshes than the previous selection and the previous sub-mesh had a higher index selected than the total number of submeshes of the new object no IndexOutOfBounds occurs during runtime.

AC:

One can change the objects from the material selector with no complication, even if the objects have different numbers of sub-meshes.

The material selector is still working with no errors after the object of the material selector has been changed.

When the object is changed the index of the selected submesh is reset to cero.