### PR TITLE
REUP-110 added functionalty for multiple lightmaps

### DIFF
--- a/Assets/Quickstart/BaseGlobalScripts.prefab
+++ b/Assets/Quickstart/BaseGlobalScripts.prefab
@@ -34,6 +34,7 @@ Transform:
   - {fileID: 9178778513458814053}
   - {fileID: 8577674977601168461}
   - {fileID: 987618495}
+  - {fileID: 7151747887374838659}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -390,6 +391,68 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 2408048958117119621, guid: 281dfd7f67fa78441a885554dcd44052, type: 3}
   m_PrefabInstance: {fileID: 6224289380651934408}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7679537917074905515
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6056801452590680388}
+    m_Modifications:
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2271680273905671913, guid: a5484927732f017418b803a77ef68388, type: 3}
+      propertyPath: m_Name
+      value: ChangeLightmap
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a5484927732f017418b803a77ef68388, type: 3}
+--- !u!4 &7151747887374838659 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 707962084956320296, guid: a5484927732f017418b803a77ef68388, type: 3}
+  m_PrefabInstance: {fileID: 7679537917074905515}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7771124988216657285
 PrefabInstance:

--- a/Assets/Quickstart/Furniture.prefab
+++ b/Assets/Quickstart/Furniture.prefab
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3221377006821011999
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2796497801391863926}
+  - component: {fileID: -5479135401294128618}
+  m_Layer: 0
+  m_Name: Furniture
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2796497801391863926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3221377006821011999}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-5479135401294128618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3221377006821011999}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 98c981de3e779a44e9e4f7b806e94eb5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lightmapChanger: {fileID: 0}
+  resourceFolder: 

--- a/Assets/Quickstart/Furniture.prefab.meta
+++ b/Assets/Quickstart/Furniture.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5162254611fc39b4d8f6dec922dd2968
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptHolders/ChangeLightmap.prefab
+++ b/Assets/ScriptHolders/ChangeLightmap.prefab
@@ -1,0 +1,56 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2271680273905671913
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 707962084956320296}
+  - component: {fileID: -41324865407877258}
+  m_Layer: 0
+  m_Name: ChangeLightmap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &707962084956320296
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2271680273905671913}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-41324865407877258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2271680273905671913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 064a1938aa0b96340a32e952900e01b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_resourceFolder: LightMapData_1
+  lightingScenariosData:
+    rendererInfos: []
+    lightmaps: []
+    lightmapsDir: []
+    lightmapsShadow: []
+    lightmapsMode: 0
+    lightProbes: []
+  loadOnAwake: 0
+  verbose: 0

--- a/Assets/ScriptHolders/ChangeLightmap.prefab.meta
+++ b/Assets/ScriptHolders/ChangeLightmap.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a5484927732f017418b803a77ef68388
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ChangeLightmapInspector.cs
+++ b/Editor/ChangeLightmapInspector.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using UnityEditor;
+using ReupVirtualTwin.behaviours;
+
+
+[CustomEditor(typeof(ChangeLightmap))]
+public class ChangeLightmapInspector : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        base.OnInspectorGUI();
+
+        ChangeLightmap lightmapData = (ChangeLightmap)target;
+
+        if (GUILayout.Button("Load"))
+        {
+            lightmapData.Load();
+        }
+        if (GUILayout.Button("Save"))
+        {
+            if (lightmapData.CheckResourcesDirectoryExists(lightmapData.resourceFolder))
+            {
+                if (!EditorUtility.DisplayDialog("Overwrite Lightmap Resources?", "Lighmap Resources folder with name: \"" + lightmapData.resourceFolder + "\" already exists.\n\nPress OK to overwrite existing lightmap data.", "OK", "Cancel"))
+                {
+                    return;
+                }
+            }
+            else
+            {
+                if (!EditorUtility.DisplayDialog("Create Lightmap Resources?", "Create new lighmap Resources folder: \"" + lightmapData.resourceFolder + "?", "OK", "Cancel"))
+                {
+                    return;
+                }
+            }
+            lightmapData.GenerateLightmapInfoStore();
+        }
+    }
+}

--- a/Editor/ChangeLightmapInspector.cs.meta
+++ b/Editor/ChangeLightmapInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 762f2811d1cade64295c0450c597c05a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/reup.romulo.Editor.asmdef
+++ b/Editor/reup.romulo.Editor.asmdef
@@ -10,7 +10,8 @@
         "GUID:51949aeab7ddd114ea276b96726cb4bb",
         "GUID:5f723ba0ce93eb64ca6f59169571c5ed",
         "GUID:b3e03b714bd206c43be1c14e98aa81df",
-        "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba"
+        "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba",
+        "GUID:1772869efacc54544ac5d329d23fc591"
     ],
     "includePlatforms": [
         "Editor"

--- a/Runtime/Behaviours/ChangeLightmap.cs
+++ b/Runtime/Behaviours/ChangeLightmap.cs
@@ -1,0 +1,339 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+using System;
+using System.IO;
+using System.Collections.Generic;
+
+public class ChangeLightmap : MonoBehaviour
+{
+    private string jsonFileName = "lightmapconfig.txt"; // Name of the json data file.
+    [SerializeField] private string m_resourceFolder = "LightMapData_1";
+    public string resourceFolder { get { return m_resourceFolder; } }
+
+    private string absoluteName;
+
+    [System.Serializable]
+    private class SphericalHarmonics
+    {
+        public float[] coefficients = new float[27];
+    }
+
+    [System.Serializable]
+    private class RendererInfo
+    {
+        public Renderer renderer;
+        public int lightmapIndex;
+        public Vector4 lightmapOffsetScale;
+    }
+
+    [System.Serializable]
+    private class LightingScenarioData
+    {
+        public RendererInfo[] rendererInfos;
+        public Texture2D[] lightmaps;
+        public Texture2D[] lightmapsDir;
+        public Texture2D[] lightmapsShadow;
+        public LightmapsMode lightmapsMode;
+        public SphericalHarmonics[] lightProbes;
+    }
+
+    [SerializeField]
+    private LightingScenarioData lightingScenariosData;
+
+    [SerializeField] private bool loadOnAwake = false; // Load the selected lighmap when this script wakes up (aka when game starts).
+
+    //TODO : enable logs only when verbose enabled
+    [SerializeField] private bool verbose = false;
+
+    public string GetResourcesDirectory(string dir)
+    {
+        return Application.dataPath + "/Resources/" + dir + "/"; // The directory where the lightmap data resides.
+    }
+
+    public bool CheckResourcesDirectoryExists(string dir)
+    {
+        return Directory.Exists(GetResourcesDirectory(dir));
+    }
+
+    private void CreateResourcesDirectory(string dir)
+    {
+        if (!CheckResourcesDirectoryExists(m_resourceFolder))
+        {
+            Directory.CreateDirectory(GetResourcesDirectory(dir));
+        }
+    }
+
+    public void Load(string folderName)
+    {
+        m_resourceFolder = folderName;
+        Load();
+    }
+    public void Load()
+    {
+        lightingScenariosData = LoadJsonData();
+
+        var newLightmaps = new LightmapData[lightingScenariosData.lightmaps.Length];
+
+        for (int i = 0; i < newLightmaps.Length; i++)
+        {
+            newLightmaps[i] = new LightmapData();
+            print(m_resourceFolder + "/" + lightingScenariosData.lightmaps[i].name);
+            newLightmaps[i].lightmapColor = Resources.Load<Texture2D>(m_resourceFolder + "/" + lightingScenariosData.lightmaps[i].name);
+
+            if (lightingScenariosData.lightmapsMode != LightmapsMode.NonDirectional)
+            {
+                newLightmaps[i].lightmapDir = Resources.Load<Texture2D>(m_resourceFolder + "/" + lightingScenariosData.lightmapsDir[i].name);
+                if (lightingScenariosData.lightmapsShadow[i] != null)
+                { // If the textuer existed and was set in the data file.
+                    newLightmaps[i].shadowMask = Resources.Load<Texture2D>(m_resourceFolder + "/" + lightingScenariosData.lightmapsShadow[i].name);
+                }
+            }
+        }
+
+        LoadLightProbes();
+        ApplyRendererInfo(lightingScenariosData.rendererInfos);
+
+        LightmapSettings.lightmaps = newLightmaps;
+    }
+
+    private void LoadLightProbes()
+    {
+        var sphericalHarmonicsArray = new SphericalHarmonicsL2[lightingScenariosData.lightProbes.Length];
+
+        for (int i = 0; i < lightingScenariosData.lightProbes.Length; i++)
+        {
+            var sphericalHarmonics = new SphericalHarmonicsL2();
+
+            // j is coefficient
+            for (int j = 0; j < 3; j++)
+            {
+                //k is channel ( r g b )
+                for (int k = 0; k < 9; k++)
+                {
+                    sphericalHarmonics[j, k] = lightingScenariosData.lightProbes[i].coefficients[j * 9 + k];
+                }
+            }
+
+            sphericalHarmonicsArray[i] = sphericalHarmonics;
+        }
+
+        try
+        {
+            LightmapSettings.lightProbes.bakedProbes = sphericalHarmonicsArray;
+        }
+        catch { Debug.LogWarning("Warning, error when trying to load lightprobes for scenario "); }
+    }
+
+    private void ApplyRendererInfo(RendererInfo[] infos)
+    {
+        try
+        {
+            for (int i = 0; i < infos.Length; i++)
+            {
+                var info = infos[i];
+                info.renderer.lightmapIndex = infos[i].lightmapIndex;
+                if (!info.renderer.isPartOfStaticBatch)
+                {
+                    info.renderer.lightmapScaleOffset = infos[i].lightmapOffsetScale;
+                }
+                if (info.renderer.isPartOfStaticBatch && verbose == true)
+                {
+                    Debug.Log("Object " + info.renderer.gameObject.name + " is part of static batch, skipping lightmap offset and scale.");
+                }
+            }
+        }
+
+        catch (Exception e)
+        {
+            Debug.LogError("Error in ApplyRendererInfo:" + e.GetType().ToString());
+        }
+    }
+
+
+
+    public static ChangeLightmap instance;
+    private void Awake()
+    {
+        if (instance != null)
+        { // Singleton pattern.
+            Destroy(gameObject);
+        }
+        else
+        {
+            instance = this;
+        }
+
+        if (loadOnAwake)
+        {
+            Load();
+        }
+    }
+
+    private void WriteJsonFile(string path, string json)
+    {
+        absoluteName = path + jsonFileName;
+        File.WriteAllText(absoluteName, json); // Write all the data to the file.
+    }
+
+    private string GetJsonFile(string f)
+    {
+        if (!File.Exists(f))
+        {
+            return "";
+        }
+        return File.ReadAllText(f); // Write all the data to the file.
+    }
+
+    private LightingScenarioData LoadJsonData()
+    {
+        absoluteName = GetResourcesDirectory(m_resourceFolder) + jsonFileName;
+        string json = GetJsonFile(absoluteName);
+        return lightingScenariosData = JsonUtility.FromJson<LightingScenarioData>(json);
+    }
+
+    public void GenerateLightmapInfoStore()
+    {
+        lightingScenariosData = new LightingScenarioData();
+        var newRendererInfos = new List<RendererInfo>();
+        var newLightmapsTextures = new List<Texture2D>();
+        var newLightmapsTexturesDir = new List<Texture2D>();
+        var newLightmapsTexturesShadow = new List<Texture2D>();
+        var newLightmapsMode = new LightmapsMode();
+        var newSphericalHarmonicsList = new List<SphericalHarmonics>();
+
+        newLightmapsMode = LightmapSettings.lightmapsMode;
+
+        var renderers = FindObjectsOfType(typeof(MeshRenderer));
+        Debug.Log("stored info for " + renderers.Length + " meshrenderers");
+        foreach (MeshRenderer renderer in renderers)
+        {
+
+            if (renderer.lightmapIndex != -1)
+            {
+                RendererInfo info = new RendererInfo();
+                info.renderer = renderer;
+                info.lightmapOffsetScale = renderer.lightmapScaleOffset;
+
+                Texture2D lightmaplight = LightmapSettings.lightmaps[renderer.lightmapIndex].lightmapColor;
+                info.lightmapIndex = newLightmapsTextures.IndexOf(lightmaplight);
+                if (info.lightmapIndex == -1)
+                {
+                    info.lightmapIndex = newLightmapsTextures.Count;
+                    newLightmapsTextures.Add(lightmaplight);
+                }
+
+                if (newLightmapsMode != LightmapsMode.NonDirectional)
+                {
+                    //first directional lighting
+                    Texture2D lightmapdir = LightmapSettings.lightmaps[renderer.lightmapIndex].lightmapDir;
+                    info.lightmapIndex = newLightmapsTexturesDir.IndexOf(lightmapdir);
+                    if (info.lightmapIndex == -1)
+                    {
+                        info.lightmapIndex = newLightmapsTexturesDir.Count;
+                        newLightmapsTexturesDir.Add(lightmapdir);
+                    }
+                    //now the shadowmask
+                    Texture2D lightmapshadow = LightmapSettings.lightmaps[renderer.lightmapIndex].shadowMask;
+                    info.lightmapIndex = newLightmapsTexturesShadow.IndexOf(lightmapshadow);
+                    if (info.lightmapIndex == -1)
+                    {
+                        info.lightmapIndex = newLightmapsTexturesShadow.Count;
+                        newLightmapsTexturesShadow.Add(lightmapshadow);
+                    }
+
+                }
+                newRendererInfos.Add(info);
+            }
+        }
+
+
+        lightingScenariosData.lightmapsMode = newLightmapsMode;
+        lightingScenariosData.lightmaps = newLightmapsTextures.ToArray();
+
+        if (newLightmapsMode != LightmapsMode.NonDirectional)
+        {
+            lightingScenariosData.lightmapsDir = newLightmapsTexturesDir.ToArray();
+            lightingScenariosData.lightmapsShadow = newLightmapsTexturesShadow.ToArray();
+        }
+
+        lightingScenariosData.rendererInfos = newRendererInfos.ToArray();
+
+        var scene_LightProbes = new SphericalHarmonicsL2[LightmapSettings.lightProbes.bakedProbes.Length];
+        scene_LightProbes = LightmapSettings.lightProbes.bakedProbes;
+
+        for (int i = 0; i < scene_LightProbes.Length; i++)
+        {
+            var SHCoeff = new SphericalHarmonics();
+
+            // j is coefficient
+            for (int j = 0; j < 3; j++)
+            {
+                //k is channel ( r g b )
+                for (int k = 0; k < 9; k++)
+                {
+                    SHCoeff.coefficients[j * 9 + k] = scene_LightProbes[i][j, k];
+                }
+            }
+
+            newSphericalHarmonicsList.Add(SHCoeff);
+        }
+
+        lightingScenariosData.lightProbes = newSphericalHarmonicsList.ToArray();
+
+        // write the files and map config data.
+        CreateResourcesDirectory(m_resourceFolder);
+
+        string resourcesDir = GetResourcesDirectory(m_resourceFolder);
+        CopyTextureToResources(resourcesDir, lightingScenariosData.lightmaps);
+        CopyTextureToResources(resourcesDir, lightingScenariosData.lightmapsDir);
+        CopyTextureToResources(resourcesDir, lightingScenariosData.lightmapsShadow);
+
+        string json = JsonUtility.ToJson(lightingScenariosData);
+        WriteJsonFile(resourcesDir, json);
+    }
+
+    private void CopyTextureToResources(string toPath, Texture2D[] textures)
+    {
+        for (int i = 0; i < textures.Length; i++)
+        {
+            Texture2D texture = textures[i];
+            if (texture != null) // Maybe the optional shadowmask didn't exist?
+            {
+                FileUtil.ReplaceFile(
+                    AssetDatabase.GetAssetPath(texture),
+                    toPath + Path.GetFileName(AssetDatabase.GetAssetPath(texture))
+                );
+                AssetDatabase.Refresh(); // Refresh so the newTexture file can be found and loaded.
+                Texture2D newTexture = Resources.Load<Texture2D>(m_resourceFolder + "/" + texture.name); // Load the new texture as an object.
+
+                CopyTextureImporterProperties(textures[i], newTexture); // Ensure new texture takes on same properties as origional texture.
+
+                AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(newTexture)); // Re-import texture file so it will be successfully compressed to desired format.
+                EditorUtility.CompressTexture(newTexture, textures[i].format, TextureCompressionQuality.Best); // Now compress the texture.
+
+                textures[i] = newTexture; // Set the new texture as the reference in the Json file.
+            }
+        }
+    }
+
+    private void CopyTextureImporterProperties(Texture2D fromTexture, Texture2D toTexture)
+    {
+        TextureImporter fromTextureImporter = GetTextureImporter(fromTexture);
+        TextureImporter toTextureImporter = GetTextureImporter(toTexture);
+
+        toTextureImporter.wrapMode = fromTextureImporter.wrapMode;
+        toTextureImporter.anisoLevel = fromTextureImporter.anisoLevel;
+        toTextureImporter.sRGBTexture = fromTextureImporter.sRGBTexture;
+        toTextureImporter.textureType = fromTextureImporter.textureType;
+        toTextureImporter.textureCompression = fromTextureImporter.textureCompression;
+    }
+
+    private TextureImporter GetTextureImporter(Texture2D texture)
+    {
+        string newTexturePath = AssetDatabase.GetAssetPath(texture);
+        TextureImporter importer = AssetImporter.GetAtPath(newTexturePath) as TextureImporter;
+        return importer;
+    }
+
+}

--- a/Runtime/Behaviours/ChangeLightmap.cs.meta
+++ b/Runtime/Behaviours/ChangeLightmap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 064a1938aa0b96340a32e952900e01b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Behaviours/ChangeLightmapController.cs
+++ b/Runtime/Behaviours/ChangeLightmapController.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+public class ChangeLightmapController : MonoBehaviour
+{
+
+    ChangeLightmap lightmapChanger = new ChangeLightmap();
+    [SerializeField] string resourceFolderFurniture;
+    [SerializeField] string resourceFolderNoFurniture;
+
+    void OnEnable()
+    {
+        lightmapChanger.Load(resourceFolderFurniture);
+    }
+
+    private void OnDisable()
+    {
+        lightmapChanger.Load(resourceFolderNoFurniture);
+    }
+
+}

--- a/Runtime/Behaviours/ChangeLightmapController.cs.meta
+++ b/Runtime/Behaviours/ChangeLightmapController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98c981de3e779a44e9e4f7b806e94eb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Behaviours/ShowFurniture.cs
+++ b/Runtime/Behaviours/ShowFurniture.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class ShowFurniture : MonoBehaviour
@@ -7,13 +5,7 @@ public class ShowFurniture : MonoBehaviour
     [SerializeField]
     GameObject furniture;
 
-    // Update is called once per frame
-    void Update()
-    {
-    }
-
     public void toggleShowFurniture(bool toggle) {
-        print(toggle);
         furniture.SetActive(toggle);
     }
 }


### PR DESCRIPTION
As a developer I would like to change the baked lightmap of a scene dynamically so that when I hide the furniture the walls no longer have projections of the shadows they projected
AC:

Exists a way for the designer to generate 2 lightmaps one with furniture and one without it so both can be saved and accessed at runtime

The lightmap es dynamically changed whenever the user turn off an on the furniture so the shadows match the actual scene.