### PR TITLE
Reup 113 change material

### DIFF
--- a/Assets/Plugins.meta
+++ b/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 86dc2842d182a9a4cb905be2c9c4fbfd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/WebInterface.jslib
+++ b/Assets/Plugins/WebInterface.jslib
@@ -1,0 +1,7 @@
+mergeInto(LibraryManager.library, {
+
+  SendMessageToWeb: function (str) {
+      window.unityMessageHandlers.receiveMessageFromUnity(UTF8ToString(str));
+  }
+
+});

--- a/Assets/Plugins/WebInterface.jslib
+++ b/Assets/Plugins/WebInterface.jslib
@@ -1,7 +1,8 @@
 mergeInto(LibraryManager.library, {
 
   SendMessageToWeb: function (str) {
-      window.unityMessageHandlers.receiveMessageFromUnity(UTF8ToString(str));
+    var data = { type: "messageFromUnity", message: UTF8ToString(str) };
+    window.postMessage(data, 'http://localhost:4200');
   }
 
 });

--- a/Assets/Plugins/WebInterface.jslib.meta
+++ b/Assets/Plugins/WebInterface.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 2a511a721db9792489b783bf9c051caa
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Quickstart/BaseGlobalScripts.prefab
+++ b/Assets/Quickstart/BaseGlobalScripts.prefab
@@ -1,5 +1,49 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5630746703695442140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6997693411884298768}
+  - component: {fileID: 4850121315665083910}
+  m_Layer: 0
+  m_Name: WebMessages
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6997693411884298768
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5630746703695442140}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.7126168, y: 1.358822, z: 9.80943}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6056801452590680388}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4850121315665083910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5630746703695442140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7445fe7907c9154198057fe7ebda33e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6056801452590680250
 GameObject:
   m_ObjectHideFlags: 0
@@ -34,6 +78,7 @@ Transform:
   - {fileID: 9178778513458814053}
   - {fileID: 8577674977601168461}
   - {fileID: 987618495}
+  - {fileID: 6997693411884298768}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Runtime/Managers/TestChangeTextureFromAngular.cs
+++ b/Runtime/Managers/TestChangeTextureFromAngular.cs
@@ -1,0 +1,40 @@
+using ReupVirtualTwin.helpers;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class TestChangeTextureFromAngular : MonoBehaviour
+{
+    public GameObject objectToChange;
+
+    MaterialsManager _materialsManager;
+    Texture2D texture;
+
+    void Start()
+    {
+        _materialsManager = ObjectFinder.FindMaterialsManager().GetComponent<MaterialsManager>();
+        _materialsManager.SelectObjects(new List<GameObject> { objectToChange }, new int[] { 0 });
+    }
+    public IEnumerator TestChangeTexture(string url)
+    {
+        yield return StartCoroutine(LoadTextureFromUrl(url));
+        var material = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+        material.SetTexture("_BaseMap", texture);
+        _materialsManager.SetNewMaterial(material);
+    }
+
+    IEnumerator LoadTextureFromUrl (string url) {
+        var image = UnityWebRequestTexture.GetTexture(url);
+        yield return image.SendWebRequest();
+        if (image.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError(image.error);
+        }
+        else
+        {
+            texture = DownloadHandlerTexture.GetContent(image);
+        }
+    }
+
+}

--- a/Runtime/Managers/TestChangeTextureFromAngular.cs.meta
+++ b/Runtime/Managers/TestChangeTextureFromAngular.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25bb40fa6a022ec4e973d51e32e4d79b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Managers/WebMessagesManager.cs
+++ b/Runtime/Managers/WebMessagesManager.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using System.Runtime.InteropServices;
+
+namespace ReupVirtualTwin.managers
+{
+    public class WebMessagesManager : MonoBehaviour
+    {
+
+#if UNITY_WEBGL
+        [DllImport("__Internal")]
+        private static extern void SendMessageToWeb(string msg);
+#endif
+
+#if UNITY_WEBGL
+        public void DoComplexCalculus(int number)
+        {
+            var otherNumber = number + 1;
+            SendMessageToWeb(otherNumber.ToString());
+        }
+#endif
+    }
+}

--- a/Runtime/Managers/WebMessagesManager.cs.meta
+++ b/Runtime/Managers/WebMessagesManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7445fe7907c9154198057fe7ebda33e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[Reup-113](https://macheight-reup.atlassian.net/browse/REUP-113?atlOrigin=eyJpIjoiYzZjYmJmN2Q0ZDM3NDE2Yjk4NjczMmRmZTRjMjEyNjUiLCJwIjoiaiJ9)

As a developer, I would like to have the ability to change the materials on existing meshes using textures that aren’t burned into the unity build so that we can have a flexible plugin system

AC:

Exists POC code that allows for applying a texture to an existing mesh in a unity web build

The texture applied was not included in the original web build for the unity scene