### PR TITLE
Change material from webrequest

### DIFF
--- a/Assets/Quickstart/BaseGlobalScripts.prefab
+++ b/Assets/Quickstart/BaseGlobalScripts.prefab
@@ -369,6 +369,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 60ada24855499274da125a7d7f12db27, type: 3}
+--- !u!1 &9178778513458814052 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3129868398788256042, guid: 60ada24855499274da125a7d7f12db27, type: 3}
+  m_PrefabInstance: {fileID: 6056801453548109134}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6739608090704594796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9178778513458814052}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25bb40fa6a022ec4e973d51e32e4d79b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  objectToChange: {fileID: 0}
 --- !u!4 &9178778513458814053 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3129868398788256043, guid: 60ada24855499274da125a7d7f12db27, type: 3}

--- a/Runtime/Managers/TestChangeTextureFromAngular.cs
+++ b/Runtime/Managers/TestChangeTextureFromAngular.cs
@@ -1,0 +1,40 @@
+using ReupVirtualTwin.helpers;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class TestChangeTextureFromAngular : MonoBehaviour
+{
+    public GameObject objectToChange;
+
+    MaterialsManager _materialsManager;
+    Texture2D texture;
+
+    void Start()
+    {
+        _materialsManager = ObjectFinder.FindMaterialsManager().GetComponent<MaterialsManager>();
+        _materialsManager.SelectObjects(new List<GameObject> { objectToChange }, new int[] { 0 });
+    }
+    public IEnumerator TestChangeTexture(string url)
+    {
+        yield return StartCoroutine(LoadTextureFromUrl(url));
+        var material = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+        material.SetTexture("_BaseMap", texture);
+        _materialsManager.SetNewMaterial(material);
+    }
+
+    IEnumerator LoadTextureFromUrl (string url) {
+        var image = UnityWebRequestTexture.GetTexture(url);
+        yield return image.SendWebRequest();
+        if (image.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError(image.error);
+        }
+        else
+        {
+            texture = DownloadHandlerTexture.GetContent(image);
+        }
+    }
+
+}

--- a/Runtime/Managers/TestChangeTextureFromAngular.cs.meta
+++ b/Runtime/Managers/TestChangeTextureFromAngular.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25bb40fa6a022ec4e973d51e32e4d79b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[Reup-113](https://macheight-reup.atlassian.net/browse/REUP-113?atlOrigin=eyJpIjoiYzZjYmJmN2Q0ZDM3NDE2Yjk4NjczMmRmZTRjMjEyNjUiLCJwIjoiaiJ9)

As a developer, I would like to have the ability to change the materials on existing meshes using textures that aren’t burned into the unity build so that we can have a flexible plugin system

AC:

Exists POC code that allows for applying a texture to an existing mesh in a unity web build

The texture applied was not included in the original web build for the unity scene