### PR TITLE
Reup 131 rotate view arrows

### DIFF
--- a/Assets/Quickstart/Character.prefab
+++ b/Assets/Quickstart/Character.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 203620775}
   - component: {fileID: 203620774}
   m_Layer: 7
-  m_Name: PointMovement
+  m_Name: PointerMovement
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -338,7 +338,6 @@ GameObject:
   - component: {fileID: 5985767643881352044}
   - component: {fileID: 7341686661031932331}
   - component: {fileID: 2420710140368993907}
-  - component: {fileID: 7341686661031932333}
   - component: {fileID: 750237606206558041}
   - component: {fileID: 7327419282567874220}
   - component: {fileID: 573970562480206382}
@@ -408,19 +407,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxStepHeight: 0.25
---- !u!114 &7341686661031932333
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 151350736762601885}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 56e78e2605d5b47b1a22da782bf8a994, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sensitivity: 0.5
 --- !u!114 &750237606206558041
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -508,6 +494,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _innerCharacterTransform: {fileID: 4912725852084423976}
   _characterPositionManager: {fileID: 2420710140368993907}
+  _characterRotationManager: {fileID: 7341686661031932331}
 --- !u!1 &3366587928214486604
 GameObject:
   m_ObjectHideFlags: 0
@@ -736,9 +723,57 @@ Transform:
   - {fileID: 1625360269}
   - {fileID: 2721092845200583677}
   - {fileID: 4016467730732689751}
+  - {fileID: 7400146765640749436}
   m_Father: {fileID: 750237606206558042}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6207187971475599429
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7400146765640749436}
+  - component: {fileID: 6562372841662299987}
+  m_Layer: 7
+  m_Name: PointerRotation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7400146765640749436
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6207187971475599429}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8380427711663556094}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6562372841662299987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6207187971475599429}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56e78e2605d5b47b1a22da782bf8a994, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sensitivity: 0.5
+  _characterRotationManager: {fileID: 7341686661031932331}
+  _dragManager: {fileID: 750237606206558041}
 --- !u!1 &7657426824907154042
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/Behaviours/CharacterMovementKeyboard.cs
+++ b/Runtime/Behaviours/CharacterMovementKeyboard.cs
@@ -11,7 +11,8 @@ public class CharacterMovementKeyboard : MonoBehaviour
     private CharacterPositionManager _characterPositionManager;
     [SerializeField]
     private CharacterRotationManager _characterRotationManager;
-    private float _walkSpeed = 3.5f;
+    private float WALK_SPEED_M_PER_SECOND = 3.5f;
+    private float ROTATION_SPEED_DEG_PER_SECOND = 180f;
 
 
     private void Awake()
@@ -35,7 +36,8 @@ public class CharacterMovementKeyboard : MonoBehaviour
         if (direction != 0f)
         {
             Debug.Log($"the direction is {direction}");
-            _characterRotationManager.horizontalRotation += direction;
+            float angleDelta = direction * ROTATION_SPEED_DEG_PER_SECOND * Time.deltaTime;
+            _characterRotationManager.horizontalRotation += angleDelta;
         }
     }
 
@@ -45,7 +47,7 @@ public class CharacterMovementKeyboard : MonoBehaviour
         if (movementDirection != Vector3.zero && _characterPositionManager.allowWalking)
         {
             _characterPositionManager.StopWalking();
-            _characterPositionManager.MoveInDirection(movementDirection, _walkSpeed);
+            _characterPositionManager.MoveInDirection(movementDirection, WALK_SPEED_M_PER_SECOND);
         }
     }
 

--- a/Runtime/Behaviours/CharacterMovementKeyboard.cs
+++ b/Runtime/Behaviours/CharacterMovementKeyboard.cs
@@ -9,6 +9,8 @@ public class CharacterMovementKeyboard : MonoBehaviour
     private InputProvider _inputProvider;
     [SerializeField]
     private CharacterPositionManager _characterPositionManager;
+    [SerializeField]
+    private CharacterRotationManager _characterRotationManager;
     private float _walkSpeed = 3.5f;
 
 
@@ -25,8 +27,21 @@ public class CharacterMovementKeyboard : MonoBehaviour
     private void UpdatePosition()
     {
         Vector2 inputValue = _inputProvider.MovementInput().normalized;
-        Vector3 movementDirection = inputValue.x * GetCharacterRight() +
-                            inputValue.y * GetCharacterForward();
+        PerformForwardBackwardMovement(inputValue.y);
+        PerformRotation(inputValue.x);
+    }
+    private void PerformRotation(float direction)
+    {
+        if (direction != 0f)
+        {
+            Debug.Log($"the direction is {direction}");
+            _characterRotationManager.horizontalRotation += direction;
+        }
+    }
+
+    private void PerformForwardBackwardMovement(float direction)
+    {
+        Vector3 movementDirection =  direction * GetCharacterForward();
         if (movementDirection != Vector3.zero && _characterPositionManager.allowWalking)
         {
             _characterPositionManager.StopWalking();
@@ -34,12 +49,6 @@ public class CharacterMovementKeyboard : MonoBehaviour
         }
     }
 
-    private Vector3 GetCharacterRight()
-    {
-        Vector3 right = _innerCharacterTransform.right;
-        right.y = 0;
-        return right;
-    }
     private Vector3 GetCharacterForward()
     {
         Vector3 forward = _innerCharacterTransform.forward;

--- a/Runtime/Behaviours/PointerRotation.cs
+++ b/Runtime/Behaviours/PointerRotation.cs
@@ -4,15 +4,15 @@ public class PointerRotation : MonoBehaviour
 {
     public float sensitivity = 0.4f;
 
+    [SerializeField]
     private CharacterRotationManager _characterRotationManager;
-    private InputProvider _inputProvider;
+    [SerializeField]
     private DragManager _dragManager;
+    private InputProvider _inputProvider;
 
     private void Awake()
     {
         _inputProvider = new InputProvider();
-        _dragManager = GetComponent<DragManager>();
-        _characterRotationManager = GetComponent<CharacterRotationManager>();
     }
 
     void Update()


### PR DESCRIPTION
[Reup-131](https://macheight-reup.atlassian.net/browse/REUP-131?atlOrigin=eyJpIjoiNGYzNDY2OTE5NGFiNDQ5NmE0ZmRiZWQwNTdiMjdjZmQiLCJwIjoiaiJ9)

As a user I’d like to make the side arrows rotate the character view angle instead of translating sideways, so I have a more natural way of interacting with the module.

AC:

The side arrows rotate the view.