### PR TITLE
Generate id when adding id component

### DIFF
--- a/Editor/UniqueIdentifierDrawer.cs
+++ b/Editor/UniqueIdentifierDrawer.cs
@@ -10,13 +10,6 @@ namespace ReupVirtualTwin.editor
 	{
 		public override void OnGUI(Rect position, SerializedProperty prop, GUIContent label)
 		{
-			// Generate a unique ID, defaults to an empty string if nothing has been serialized yet
-			if (string.IsNullOrEmpty(prop.stringValue))
-			{
-				Guid guid = Guid.NewGuid();
-				prop.stringValue = guid.ToString();
-			}
-
 			// Place a label so it can't be edited by accident
 			Rect textFieldPosition = position;
 			textFieldPosition.height = 16;

--- a/Runtime/Behaviours/AssignIds.cs
+++ b/Runtime/Behaviours/AssignIds.cs
@@ -10,7 +10,8 @@ namespace ReupVirtualTwin.behaviours
         {
             if (parent.GetComponent<IUniqueIdentifer>() == null)
             {
-                parent.AddComponent<RegisteredIdentifier>();
+                IUniqueIdentifer uniqueId = parent.AddComponent<RegisteredIdentifier>();
+                uniqueId.GenerateId();
             }
 
             foreach (Transform child in parent.transform)

--- a/Runtime/ModelInterfaces/IUniqueIdentifer.cs
+++ b/Runtime/ModelInterfaces/IUniqueIdentifer.cs
@@ -5,5 +5,6 @@ namespace ReupVirtualTwin.modelInterfaces
     {
         public string getId();
         public bool isIdCorrect(string id);
+        public string GenerateId();
     }
 }

--- a/Runtime/Models/UniqueId.cs
+++ b/Runtime/Models/UniqueId.cs
@@ -11,6 +11,16 @@ namespace ReupVirtualTwin.models
 		[UniqueIdentifier]
 		public string uniqueId;
 
+        public string GenerateId()
+        {
+            if (uniqueId == null || uniqueId == "")
+            {
+                Guid guid = Guid.NewGuid();
+                uniqueId = guid.ToString();
+            }
+            return uniqueId;
+        }
+
         public string getId()
         {
             return uniqueId;


### PR DESCRIPTION
Object Ids where being generated only when the object inspector was open in the editor.

This was causing non consistent ids for objects that where never manually inspected before build.

Now they are being generated when the Id component is added to the object.