### PR TITLE
Refactor Manual Id

### DIFF
--- a/Editor/RegisteredIdentifierEditor.cs
+++ b/Editor/RegisteredIdentifierEditor.cs
@@ -7,7 +7,10 @@ public class RegisteredIdentifierEditor : Editor
     public override void OnInspectorGUI()
     {
         base.OnInspectorGUI();
-        UniqueId Identifier = (RegisteredIdentifier)target;
-        EditorGUILayout.TextField("copy and paste it!", Identifier.uniqueId);
+        RegisteredIdentifier identifier = (RegisteredIdentifier)target;
+        if (string.IsNullOrEmpty(identifier.manualId))
+        {
+            identifier.manualId = identifier.uniqueId;
+        }
     }
 }

--- a/Runtime/Models/RegisteredIdentifier.cs
+++ b/Runtime/Models/RegisteredIdentifier.cs
@@ -10,7 +10,7 @@ namespace ReupVirtualTwin.models
         protected override void Start()
         {
             base.Start();
-            if (!string.IsNullOrEmpty(manualId))
+            if (manualId != uniqueId)
             {
                 uniqueId = manualId;
             }


### PR DESCRIPTION
now If the manual ID is empty, is filled with the uniqueId
if it's different than the uniqueId, the uniqueId becomes the manualId during runtime