### PR TITLE
Reup183 tag system

### DIFF
--- a/Assets/ScriptHolders/EditionMediator.prefab
+++ b/Assets/ScriptHolders/EditionMediator.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 5511850582633369602}
   - component: {fileID: 8950963653470224177}
   - component: {fileID: 6976859030307673124}
+  - component: {fileID: 4473605233059834508}
   m_Layer: 0
   m_Name: EditionMediator
   m_TagString: Untagged
@@ -74,6 +75,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c7445fe7907c9154198057fe7ebda33e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4473605233059834508
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3831656627378006908}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68ff9d3c632e116428cdd4126532d9cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1219849452472425799

--- a/Assets/ScriptHolders/SelectedObjectsManager.prefab
+++ b/Assets/ScriptHolders/SelectedObjectsManager.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 4879889724370832318}
   - component: {fileID: 7328548031457494451}
   - component: {fileID: 7538679804722216734}
+  - component: {fileID: 4424209672600465725}
   m_Layer: 0
   m_Name: SelectedObjectsManager
   m_TagString: Untagged
@@ -61,6 +62,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b0a0d81e93e1b54591e33d413b86702, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  mediator: {fileID: 0}
 --- !u!114 &2557996600432680719
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -110,5 +112,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c7445fe7907c9154198057fe7ebda33e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4424209672600465725
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4786376132976531946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68ff9d3c632e116428cdd4126532d9cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/ScriptHolders/SetUpBuilding.prefab
+++ b/Assets/ScriptHolders/SetUpBuilding.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2408048958117119621}
   - component: {fileID: 7408776217132404189}
+  - component: {fileID: 4256434577350106874}
   m_Layer: 0
   m_Name: SetUpBuilding
   m_TagString: SetupBuilding
@@ -45,3 +46,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   building: {fileID: 0}
+--- !u!114 &4256434577350106874
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7145843182074020279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3097591da4ae85a49bc26e0032bdb407, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Editor/SetUpBuildingEditor.cs
+++ b/Editor/SetUpBuildingEditor.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEditor;
+using ReupVirtualTwin.behaviourInterfaces;
 using ReupVirtualTwin.behaviours;
 
 namespace ReupVirtualTwin.editor
@@ -7,23 +8,37 @@ namespace ReupVirtualTwin.editor
     [CustomEditor(typeof(SetUpBuilding))]
     public class SetUpBuildingEditor : Editor
     {
+        bool showIdsOptions = false;
+        bool showTagsOptions = false;
         public override void OnInspectorGUI()
         {
             base.OnInspectorGUI();
 
-            SetUpBuilding setUpBuilding = (SetUpBuilding)target;
+            ISetUpBuilding setUpBuilding = (ISetUpBuilding)target;
 
-            if (GUILayout.Button("Add Ids to objects"))
+            showIdsOptions = EditorGUILayout.Foldout(showIdsOptions, "Objects Ids");
+            if (showIdsOptions)
             {
-                setUpBuilding.AssignIdsToBuilding();
+                if (GUILayout.Button("Add Ids to objects"))
+                {
+                    setUpBuilding.AssignIdsToBuilding();
+                }
+                if (GUILayout.Button("Remove Ids from objects"))
+                {
+                    setUpBuilding.RemoveIdsOfBuilding();
+                }
+                if (GUILayout.Button("Reset Ids from objects"))
+                {
+                    setUpBuilding.ResetIdsOfBuilding();
+                }
             }
-            if (GUILayout.Button("Remove Ids from objects"))
+            showTagsOptions = EditorGUILayout.Foldout(showTagsOptions, "Objects Ids");
+            if (showTagsOptions)
             {
-                setUpBuilding.RemoveIdsOfBuilding();
-            }
-            if (GUILayout.Button("Reset Ids from objects"))
-            {
-                setUpBuilding.ResetIdsOfBuilding();
+                if (GUILayout.Button("Add tag system to objects"))
+                {
+                    setUpBuilding.AddTagSystemToBuildingObjects();
+                }
             }
         }
     }

--- a/Editor/SetUpBuildingEditor.cs
+++ b/Editor/SetUpBuildingEditor.cs
@@ -32,7 +32,7 @@ namespace ReupVirtualTwin.editor
                     setUpBuilding.ResetIdsOfBuilding();
                 }
             }
-            showTagsOptions = EditorGUILayout.Foldout(showTagsOptions, "Objects Ids");
+            showTagsOptions = EditorGUILayout.Foldout(showTagsOptions, "Objects Tags");
             if (showTagsOptions)
             {
                 if (GUILayout.Button("Add tag system to objects"))

--- a/Editor/reup.romulo.Editor.asmdef
+++ b/Editor/reup.romulo.Editor.asmdef
@@ -11,7 +11,8 @@
         "GUID:5f723ba0ce93eb64ca6f59169571c5ed",
         "GUID:b3e03b714bd206c43be1c14e98aa81df",
         "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba",
-        "GUID:1772869efacc54544ac5d329d23fc591"
+        "GUID:1772869efacc54544ac5d329d23fc591",
+        "GUID:0da6763f50b07ec4c9363bdf3985cee5"
     ],
     "includePlatforms": [
         "Editor"

--- a/Runtime/Behaviours/SetUpBuilding.cs
+++ b/Runtime/Behaviours/SetUpBuilding.cs
@@ -10,6 +10,7 @@ namespace ReupVirtualTwin.behaviours
         [SerializeField]
         GameObject building;
         private bool buildingSetup = false;
+        private ITagSystemAssigner _tagSystemAssigner;
 
         event Action _onBuildingSetUp;
         public event Action onBuildingSetUp
@@ -42,16 +43,27 @@ namespace ReupVirtualTwin.behaviours
         public void AssignIdsToBuilding()
         {
             AssignIds.AssignToTree(building);
+            Debug.Log("Ids added to tree");
         }
         public void RemoveIdsOfBuilding()
         {
             AssignIds.RemoveFromTree(building);
+            Debug.Log("Ids removed from tree");
         }
         public void ResetIdsOfBuilding()
         {
             RemoveIdsOfBuilding();
             AssignIdsToBuilding();
+            Debug.Log("Ids reseted from tree");
         }
 
+        public void AddTagSystemToBuildingObjects()
+        {
+            if (_tagSystemAssigner == null)
+            {
+                _tagSystemAssigner = GetComponent<ITagSystemAssigner>();
+            }
+            _tagSystemAssigner.AssignTagSystemToTree(building);
+        }
     }
 }

--- a/Runtime/Behaviours/SetUpBuilding.cs
+++ b/Runtime/Behaviours/SetUpBuilding.cs
@@ -64,6 +64,7 @@ namespace ReupVirtualTwin.behaviours
                 _tagSystemAssigner = GetComponent<ITagSystemAssigner>();
             }
             _tagSystemAssigner.AssignTagSystemToTree(building);
+            Debug.Log("tag script added to tree");
         }
     }
 }

--- a/Runtime/Behaviours/TagSystemAssigner.cs
+++ b/Runtime/Behaviours/TagSystemAssigner.cs
@@ -1,0 +1,38 @@
+using ReupVirtualTwin.behaviourInterfaces;
+using ReupVirtualTwin.modelInterfaces;
+using ReupVirtualTwin.models;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.behaviours
+{
+    public class TagSystemAssigner : MonoBehaviour, ITagSystemAssigner
+    {
+        public void AssignTagSystemToTree(GameObject tree)
+        {
+            if (tree.GetComponent<IObjectTags>() == null)
+            {
+                tree.AddComponent<ObjectTags>();
+            }
+
+            foreach (Transform child in tree.transform)
+            {
+                AssignTagSystemToTree(child.gameObject);
+            }
+        }
+
+        public void RemoveTagSystemFromTree(GameObject tree)
+        {
+            IObjectTags objectTags = tree.GetComponent<IObjectTags>();
+            if (objectTags != null)
+            {
+                Object.DestroyImmediate((Object)objectTags);
+            }
+            foreach (Transform child in tree.transform)
+            {
+                RemoveTagSystemFromTree(child.gameObject);
+            }
+        }
+    }
+}

--- a/Runtime/Behaviours/TagSystemAssigner.cs.meta
+++ b/Runtime/Behaviours/TagSystemAssigner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3097591da4ae85a49bc26e0032bdb407
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Behaviours/TagsHandler.cs
+++ b/Runtime/Behaviours/TagsHandler.cs
@@ -1,9 +1,8 @@
 using ReupVirtualTwin.behaviourInterfaces;
 using ReupVirtualTwin.enums;
 using ReupVirtualTwin.modelInterfaces;
-using System.Collections;
 using System.Collections.Generic;
-using TriLibCore.Interfaces;
+using System.Linq;
 using UnityEngine;
 
 namespace ReupVirtualTwin.behaviours
@@ -14,6 +13,18 @@ namespace ReupVirtualTwin.behaviours
         {
             IObjectTags objectTags = obj.GetComponent<IObjectTags>();
             return objectTags.AddTag(tag);
+        }
+
+        public bool DoesObjectHaveTag(GameObject obj, ObjectTag tag)
+        {
+            List<ObjectTag> tags = GetTagsFromObject(obj);
+            return tags.Contains(tag);
+        }
+
+        public string[] GetTagNamesFromObject(GameObject obj)
+        {
+            List<ObjectTag> tags = GetTagsFromObject(obj);
+            return tags.Select(tag => tag.ToString()).ToArray();
         }
 
         public List<ObjectTag> GetTagsFromObject(GameObject obj)

--- a/Runtime/Behaviours/TagsHandler.cs
+++ b/Runtime/Behaviours/TagsHandler.cs
@@ -1,0 +1,31 @@
+using ReupVirtualTwin.behaviourInterfaces;
+using ReupVirtualTwin.enums;
+using ReupVirtualTwin.modelInterfaces;
+using System.Collections;
+using System.Collections.Generic;
+using TriLibCore.Interfaces;
+using UnityEngine;
+
+namespace ReupVirtualTwin.behaviours
+{
+    public class TagsHandler : MonoBehaviour, ITagsHandler
+    {
+        public List<ObjectTag> AddTagToObject(GameObject obj, ObjectTag tag)
+        {
+            IObjectTags objectTags = obj.GetComponent<IObjectTags>();
+            return objectTags.AddTag(tag);
+        }
+
+        public List<ObjectTag> GetTagsFromObject(GameObject obj)
+        {
+            IObjectTags objectTags = obj.GetComponent<IObjectTags>();
+            return objectTags.GetTags();
+        }
+
+        public List<ObjectTag> RemoveTagFromOjbect(GameObject obj, ObjectTag tag)
+        {
+            IObjectTags objectTags = obj.GetComponent<IObjectTags>();
+            return objectTags.RemoveTag(tag);
+        }
+    }
+}

--- a/Runtime/Behaviours/TagsHandler.cs.meta
+++ b/Runtime/Behaviours/TagsHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68ff9d3c632e116428cdd4126532d9cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/BehavioursInterfaces/ISetUpBuilding.cs
+++ b/Runtime/BehavioursInterfaces/ISetUpBuilding.cs
@@ -5,7 +5,9 @@ namespace ReupVirtualTwin.behaviourInterfaces
     public interface ISetUpBuilding
     {
         public event Action onBuildingSetUp;
-
-
+        public void AssignIdsToBuilding();
+        public void RemoveIdsOfBuilding();
+        public void ResetIdsOfBuilding();
+        public void AddTagSystemToBuildingObjects();
     }
 }

--- a/Runtime/BehavioursInterfaces/ITagSystemAssigner.cs
+++ b/Runtime/BehavioursInterfaces/ITagSystemAssigner.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace ReupVirtualTwin.behaviourInterfaces
+{
+    public interface ITagSystemAssigner
+    {
+        public void AssignTagSystemToTree(GameObject tree);
+        public void RemoveTagSystemFromTree(GameObject tree);
+    }
+}

--- a/Runtime/BehavioursInterfaces/ITagSystemAssigner.cs.meta
+++ b/Runtime/BehavioursInterfaces/ITagSystemAssigner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f359e4367a077a41a0e9b7aceb40fe1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/BehavioursInterfaces/ITagsHandler.cs
+++ b/Runtime/BehavioursInterfaces/ITagsHandler.cs
@@ -1,4 +1,5 @@
 using ReupVirtualTwin.enums;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -9,5 +10,7 @@ namespace ReupVirtualTwin.behaviourInterfaces
         public List<ObjectTag> GetTagsFromObject(GameObject obj);
         public List<ObjectTag> AddTagToObject(GameObject obj, ObjectTag tag);
         public List<ObjectTag> RemoveTagFromOjbect(GameObject obj, ObjectTag tag);
+        public Boolean DoesObjectHaveTag(GameObject obj, ObjectTag tag);
+        public string[] GetTagNamesFromObject(GameObject obj);
     }
 }

--- a/Runtime/BehavioursInterfaces/ITagsHandler.cs
+++ b/Runtime/BehavioursInterfaces/ITagsHandler.cs
@@ -1,0 +1,13 @@
+using ReupVirtualTwin.enums;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReupVirtualTwin.behaviourInterfaces
+{
+    public interface ITagsHandler
+    {
+        public List<ObjectTag> GetTagsFromObject(GameObject obj);
+        public List<ObjectTag> AddTagToObject(GameObject obj, ObjectTag tag);
+        public List<ObjectTag> RemoveTagFromOjbect(GameObject obj, ObjectTag tag);
+    }
+}

--- a/Runtime/BehavioursInterfaces/ITagsHandler.cs.meta
+++ b/Runtime/BehavioursInterfaces/ITagsHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bc8e8dee7e89944c9578f3235bf384d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/BehavioursInterfaces/reup.romulo.behaviourInterfaces.asmdef
+++ b/Runtime/BehavioursInterfaces/reup.romulo.behaviourInterfaces.asmdef
@@ -2,7 +2,8 @@
     "name": "reup.romulo.behaviourInterfaces",
     "rootNamespace": "",
     "references": [
-        "GUID:ef71f4f9d4e9ed44987e6a7778893414"
+        "GUID:ef71f4f9d4e9ed44987e6a7778893414",
+        "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/DataModels/ObjectDTO.cs
+++ b/Runtime/DataModels/ObjectDTO.cs
@@ -1,3 +1,4 @@
+using ReupVirtualTwin.enums;
 using System;
 
 namespace ReupVirtualTwin.dataModels

--- a/Runtime/DataModels/reup.remulo.dataModels.asmdef
+++ b/Runtime/DataModels/reup.remulo.dataModels.asmdef
@@ -1,3 +1,16 @@
 {
-	"name": "reup.remulo.dataModels"
+    "name": "reup.remulo.dataModels",
+    "rootNamespace": "",
+    "references": [
+        "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Runtime/Enums/ObjectTag.cs
+++ b/Runtime/Enums/ObjectTag.cs
@@ -2,7 +2,7 @@ namespace ReupVirtualTwin.enums
 {
     public enum ObjectTag
     {
-        SELECTEABLE,
+        SELECTABLE,
         TRANSFORMABLE,
         DELETABLE,
     }

--- a/Runtime/Enums/ObjectTag.cs
+++ b/Runtime/Enums/ObjectTag.cs
@@ -1,0 +1,9 @@
+namespace ReupVirtualTwin.enums
+{
+    public enum ObjectTag
+    {
+        SELECTEABLE,
+        TRANSFORMABLE,
+        DELETABLE,
+    }
+}

--- a/Runtime/Enums/ObjectTag.cs.meta
+++ b/Runtime/Enums/ObjectTag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 827ff3f8ab1945543975c7a1973e5caa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Enums/TagsEnum.cs
+++ b/Runtime/Enums/TagsEnum.cs
@@ -12,8 +12,6 @@ namespace ReupVirtualTwin.enums
         public const string setupBuilding = "SetupBuilding";
         public const string objectRegistry = "ObjectRegistry";
         public const string setUpBuilding = "SetupBuilding";
-        public const string selectableObject = "Selectable";
-        public const string transformableObject = "Transformable";
 
         // managers
         public const string dragManager = "DragManager";

--- a/Runtime/Helpers/Selectors/ObjectSelectors/SelectableObjectSelector.cs
+++ b/Runtime/Helpers/Selectors/ObjectSelectors/SelectableObjectSelector.cs
@@ -14,7 +14,7 @@ namespace ReupVirtualTwin.helpers
         }
         protected override GameObject GetSelectedObjectFromHitObject(GameObject obj)
         {
-            if (_tagsHandler.DoesObjectHaveTag(obj, ObjectTag.SELECTEABLE))
+            if (_tagsHandler.DoesObjectHaveTag(obj, ObjectTag.SELECTABLE))
             {
                 return obj;
             }

--- a/Runtime/Helpers/Selectors/ObjectSelectors/SelectableObjectSelector.cs
+++ b/Runtime/Helpers/Selectors/ObjectSelectors/SelectableObjectSelector.cs
@@ -1,13 +1,20 @@
 using UnityEngine;
 using ReupVirtualTwin.enums;
+using ReupVirtualTwin.behaviourInterfaces;
 
 namespace ReupVirtualTwin.helpers
 {
+    [RequireComponent(typeof(ITagsHandler))]
     public class SelectableObjectSelector : ObjectSelector
     {
+        private ITagsHandler _tagsHandler;
+        private void Awake()
+        {
+            _tagsHandler = GetComponent<ITagsHandler>();
+        }
         protected override GameObject GetSelectedObjectFromHitObject(GameObject obj)
         {
-            if (obj.CompareTag(TagsEnum.selectableObject) || obj.CompareTag(TagsEnum.transformableObject))
+            if (_tagsHandler.DoesObjectHaveTag(obj, ObjectTag.SELECTEABLE))
             {
                 return obj;
             }

--- a/Runtime/Helpers/reup.romulo.helpers.asmdef
+++ b/Runtime/Helpers/reup.romulo.helpers.asmdef
@@ -6,7 +6,8 @@
         "GUID:5bd4fa32afd95b740912978471672274",
         "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba",
         "GUID:ef71f4f9d4e9ed44987e6a7778893414",
-        "GUID:b80692fab1cf7c548bafc2ed4f6ff8ea"
+        "GUID:b80692fab1cf7c548bafc2ed4f6ff8ea",
+        "GUID:0da6763f50b07ec4c9363bdf3985cee5"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/Managers/EditionMediator.cs
+++ b/Runtime/Managers/EditionMediator.cs
@@ -1,7 +1,6 @@
 using ReupVirtualTwin.managerInterfaces;
 using UnityEngine;
 using ReupVirtualTwin.enums;
-using System.Collections;
 using ReupVirtualTwin.behaviourInterfaces;
 using ReupVirtualTwin.dataModels;
 using System;
@@ -32,6 +31,12 @@ namespace ReupVirtualTwin.managers
 
         IWebMessagesSender _webMessageSender;
         public IWebMessagesSender webMessageSender { set { _webMessageSender = value; } }
+        private ITagsHandler _tagsHandler;
+
+        private void Awake()
+        {
+            _tagsHandler = GetComponent<ITagsHandler>();
+        }
 
         public void Notify(Events eventName)
         {
@@ -173,7 +178,7 @@ namespace ReupVirtualTwin.managers
                 selectedDTOObjects.Add(new ObjectDTO
                 {
                      id = objId,
-                     tags = new string[1] {obj.tag},
+                     tags = _tagsHandler.GetTagNamesFromObject(obj)
                 });
             }
             ObjectDTO[] objectDTOs = selectedDTOObjects.ToArray();

--- a/Runtime/Managers/TransformObjectsManager.cs
+++ b/Runtime/Managers/TransformObjectsManager.cs
@@ -6,6 +6,7 @@ using ReupVirtualTwin.dataModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ReupVirtualTwin.behaviourInterfaces;
 
 namespace ReupVirtualTwin.managers
 {
@@ -19,6 +20,7 @@ namespace ReupVirtualTwin.managers
         private int _runtimeTransformLayer = 6;
         private IMediator _mediator;
         public IMediator mediator { set { _mediator = value; } }
+        private ITagsHandler _tagsHandler;
 
         private GameObject _transformWrapper;
         public ObjectWrapperDTO wrapper
@@ -46,6 +48,7 @@ namespace ReupVirtualTwin.managers
             _runtimeTransformHandle.autoScaleFactor = 1.0f;
             _runtimeTransformObj.layer = _runtimeTransformLayer;
             _runtimeTransformObj.SetActive(false);
+            _tagsHandler = GetComponent<ITagsHandler>();
         }
         public void ActivateTransformMode(ObjectWrapperDTO wrapperDTO, TransformMode mode)
         {
@@ -88,7 +91,7 @@ namespace ReupVirtualTwin.managers
 
         private bool AreWrappedObjectsTransformable(List<GameObject> objects)
         {
-            return objects.All(obj => obj.CompareTag(TagsEnum.transformableObject));
+            return objects.All(obj => _tagsHandler.DoesObjectHaveTag(obj, ObjectTag.TRANSFORMABLE));
         }
 
 

--- a/Runtime/ModelInterfaces/IObjectTags.cs
+++ b/Runtime/ModelInterfaces/IObjectTags.cs
@@ -7,6 +7,7 @@ namespace ReupVirtualTwin.modelInterfaces
     {
         public List<ObjectTag> GetTags();
         public List<ObjectTag> AddTag(ObjectTag tag);
+        public List<ObjectTag> AddTags(ObjectTag[] tagsList);
         public List<ObjectTag> RemoveTag(ObjectTag tag);
     }
 }

--- a/Runtime/ModelInterfaces/IObjectTags.cs
+++ b/Runtime/ModelInterfaces/IObjectTags.cs
@@ -1,0 +1,12 @@
+using ReupVirtualTwin.enums;
+using System.Collections.Generic;
+
+namespace ReupVirtualTwin.modelInterfaces
+{
+    public interface IObjectTags
+    {
+        public HashSet<ObjectTag> tags { get; }
+        public HashSet<ObjectTag> AddTag(ObjectTag tag);
+        public HashSet<ObjectTag> RemoveTag(ObjectTag tag);
+    }
+}

--- a/Runtime/ModelInterfaces/IObjectTags.cs
+++ b/Runtime/ModelInterfaces/IObjectTags.cs
@@ -5,8 +5,8 @@ namespace ReupVirtualTwin.modelInterfaces
 {
     public interface IObjectTags
     {
-        public HashSet<ObjectTag> tags { get; }
-        public HashSet<ObjectTag> AddTag(ObjectTag tag);
-        public HashSet<ObjectTag> RemoveTag(ObjectTag tag);
+        public List<ObjectTag> GetTags();
+        public List<ObjectTag> AddTag(ObjectTag tag);
+        public List<ObjectTag> RemoveTag(ObjectTag tag);
     }
 }

--- a/Runtime/ModelInterfaces/IObjectTags.cs.meta
+++ b/Runtime/ModelInterfaces/IObjectTags.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8b920f71f94d1c449fb80108a1fed99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ModelInterfaces/reup.romulo.modelInterfaces.asmdef
+++ b/Runtime/ModelInterfaces/reup.romulo.modelInterfaces.asmdef
@@ -1,3 +1,16 @@
 {
-	"name": "reup.romulo.modelInterfaces"
+    "name": "reup.romulo.modelInterfaces",
+    "rootNamespace": "",
+    "references": [
+        "GUID:3e29f3cf4a29b6f4a8ecdaccb3a3a2ba"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Runtime/Models/ObjectTags.cs
+++ b/Runtime/Models/ObjectTags.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+using ReupVirtualTwin.enums;
+using ReupVirtualTwin.modelInterfaces;
+
+namespace ReupVirtualTwin.models
+{
+    public class ObjectTags : MonoBehaviour, IObjectTags
+    {
+        private HashSet<ObjectTag> _tags = new HashSet<ObjectTag>();
+        public HashSet<ObjectTag> tags => _tags;
+
+        public HashSet<ObjectTag> AddTag(ObjectTag tag)
+        {
+            _tags.Add(tag);
+            return _tags;
+        }
+
+        public HashSet<ObjectTag> RemoveTag(ObjectTag tag)
+        {
+            _tags.Remove(tag);
+            return _tags;
+        }
+    }
+}

--- a/Runtime/Models/ObjectTags.cs
+++ b/Runtime/Models/ObjectTags.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 using ReupVirtualTwin.enums;
 using ReupVirtualTwin.modelInterfaces;
+using System.Linq;
 
 namespace ReupVirtualTwin.models
 {
@@ -25,6 +26,12 @@ namespace ReupVirtualTwin.models
         public List<ObjectTag> RemoveTag(ObjectTag tag)
         {
             tags.Remove(tag);
+            return tags;
+        }
+
+        public List<ObjectTag> AddTags(ObjectTag[] tagsList)
+        {
+            tags.AddRange(tagsList);
             return tags;
         }
     }

--- a/Runtime/Models/ObjectTags.cs
+++ b/Runtime/Models/ObjectTags.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -7,21 +6,26 @@ using ReupVirtualTwin.modelInterfaces;
 
 namespace ReupVirtualTwin.models
 {
-    public class ObjectTags : MonoBehaviour, IObjectTags
+    public class ObjectTags : MonoBehaviour, IObjectTags 
     {
-        private HashSet<ObjectTag> _tags = new HashSet<ObjectTag>();
-        public HashSet<ObjectTag> tags => _tags;
+        [SerializeField]
+        private List<ObjectTag> tags = new List<ObjectTag>();
 
-        public HashSet<ObjectTag> AddTag(ObjectTag tag)
+        public List<ObjectTag> GetTags()
         {
-            _tags.Add(tag);
-            return _tags;
+            return tags;
         }
 
-        public HashSet<ObjectTag> RemoveTag(ObjectTag tag)
+        public List<ObjectTag> AddTag(ObjectTag tag)
         {
-            _tags.Remove(tag);
-            return _tags;
+            tags.Add(tag);
+            return tags;
+        }
+
+        public List<ObjectTag> RemoveTag(ObjectTag tag)
+        {
+            tags.Remove(tag);
+            return tags;
         }
     }
 }

--- a/Runtime/Models/ObjectTags.cs.meta
+++ b/Runtime/Models/ObjectTags.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0dcee68a5ec37a24089cfb07db79853c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/Mocks/MockSetUpBuilding.cs
+++ b/Tests/PlayMode/Mocks/MockSetUpBuilding.cs
@@ -7,5 +7,25 @@ namespace Packages.reup.romulo.Tests.PlayMode.Mocks
     class MockSetUpBuilding : ISetUpBuilding
     {
         public event System.Action onBuildingSetUp;
+
+        public void AddTagSystemToBuildingObjects()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void AssignIdsToBuilding()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void RemoveIdsOfBuilding()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ResetIdsOfBuilding()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/Tests/PlayMode/ObjectTagsTest.cs
+++ b/Tests/PlayMode/ObjectTagsTest.cs
@@ -33,21 +33,21 @@ public class ObjectTagsTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ShouldAddOneTag()
     {
-        objectTags.AddTag(ObjectTag.SELECTEABLE);
+        objectTags.AddTag(ObjectTag.SELECTABLE);
         Assert.AreEqual(1, objectTags.GetTags().Count);
-        Assert.IsTrue(objectTags.GetTags().Contains(ObjectTag.SELECTEABLE));
+        Assert.IsTrue(objectTags.GetTags().Contains(ObjectTag.SELECTABLE));
         yield return null;
     }
     [UnityTest]
     public IEnumerator ShouldRemoveOneTag()
     {
-        objectTags.AddTag(ObjectTag.SELECTEABLE);
+        objectTags.AddTag(ObjectTag.SELECTABLE);
         Assert.AreEqual(1, objectTags.GetTags().Count);
-        Assert.IsTrue(objectTags.GetTags().Contains(ObjectTag.SELECTEABLE));
+        Assert.IsTrue(objectTags.GetTags().Contains(ObjectTag.SELECTABLE));
         yield return null;
-        objectTags.RemoveTag(ObjectTag.SELECTEABLE);
+        objectTags.RemoveTag(ObjectTag.SELECTABLE);
         Assert.AreEqual(0, objectTags.GetTags().Count);
-        Assert.IsFalse(objectTags.GetTags().Contains(ObjectTag.SELECTEABLE));
+        Assert.IsFalse(objectTags.GetTags().Contains(ObjectTag.SELECTABLE));
         yield return null;
     }
 }

--- a/Tests/PlayMode/ObjectTagsTest.cs
+++ b/Tests/PlayMode/ObjectTagsTest.cs
@@ -27,27 +27,27 @@ public class ObjectTagsTest : MonoBehaviour
     [UnityTest]
     public IEnumerator ShouldInitializeWithEmptyTagsList()
     {
-        Assert.IsEmpty(objectTags.tags);
+        Assert.IsEmpty(objectTags.GetTags());
         yield return null;
     }
     [UnityTest]
     public IEnumerator ShouldAddOneTag()
     {
         objectTags.AddTag(ObjectTag.SELECTEABLE);
-        Assert.AreEqual(1, objectTags.tags.Count);
-        Assert.IsTrue(objectTags.tags.Contains(ObjectTag.SELECTEABLE));
+        Assert.AreEqual(1, objectTags.GetTags().Count);
+        Assert.IsTrue(objectTags.GetTags().Contains(ObjectTag.SELECTEABLE));
         yield return null;
     }
     [UnityTest]
     public IEnumerator ShouldRemoveOneTag()
     {
         objectTags.AddTag(ObjectTag.SELECTEABLE);
-        Assert.AreEqual(1, objectTags.tags.Count);
-        Assert.IsTrue(objectTags.tags.Contains(ObjectTag.SELECTEABLE));
+        Assert.AreEqual(1, objectTags.GetTags().Count);
+        Assert.IsTrue(objectTags.GetTags().Contains(ObjectTag.SELECTEABLE));
         yield return null;
         objectTags.RemoveTag(ObjectTag.SELECTEABLE);
-        Assert.AreEqual(0, objectTags.tags.Count);
-        Assert.IsFalse(objectTags.tags.Contains(ObjectTag.SELECTEABLE));
+        Assert.AreEqual(0, objectTags.GetTags().Count);
+        Assert.IsFalse(objectTags.GetTags().Contains(ObjectTag.SELECTEABLE));
         yield return null;
     }
 }

--- a/Tests/PlayMode/ObjectTagsTest.cs
+++ b/Tests/PlayMode/ObjectTagsTest.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+
+using ReupVirtualTwin.models;
+using ReupVirtualTwin.enums;
+
+
+public class ObjectTagsTest : MonoBehaviour
+{
+    GameObject containerGameObject;
+    ObjectTags objectTags;
+
+    [SetUp]
+    public void SetUp()
+    {
+        containerGameObject = new GameObject("container");
+        objectTags = containerGameObject.AddComponent<ObjectTags>();
+    }
+    [TearDown]
+    public void TearDown()
+    {
+        Destroy(containerGameObject);
+    }
+    [UnityTest]
+    public IEnumerator ShouldInitializeWithEmptyTagsList()
+    {
+        Assert.IsEmpty(objectTags.tags);
+        yield return null;
+    }
+    [UnityTest]
+    public IEnumerator ShouldAddOneTag()
+    {
+        objectTags.AddTag(ObjectTag.SELECTEABLE);
+        Assert.AreEqual(1, objectTags.tags.Count);
+        Assert.IsTrue(objectTags.tags.Contains(ObjectTag.SELECTEABLE));
+        yield return null;
+    }
+    [UnityTest]
+    public IEnumerator ShouldRemoveOneTag()
+    {
+        objectTags.AddTag(ObjectTag.SELECTEABLE);
+        Assert.AreEqual(1, objectTags.tags.Count);
+        Assert.IsTrue(objectTags.tags.Contains(ObjectTag.SELECTEABLE));
+        yield return null;
+        objectTags.RemoveTag(ObjectTag.SELECTEABLE);
+        Assert.AreEqual(0, objectTags.tags.Count);
+        Assert.IsFalse(objectTags.tags.Contains(ObjectTag.SELECTEABLE));
+        yield return null;
+    }
+}

--- a/Tests/PlayMode/ObjectTagsTest.cs.meta
+++ b/Tests/PlayMode/ObjectTagsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f75b6753d9cb1846ba7d338c34bcde1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/SelectedObjectsManagerTest.cs
+++ b/Tests/PlayMode/SelectedObjectsManagerTest.cs
@@ -1,9 +1,10 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using ReupVirtualTwin.managers;
 using UnityEngine.TestTools;
 using NUnit.Framework;
+
+using ReupVirtualTwin.managers;
 using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.enums;
 using ReupVirtualTwin.models;

--- a/Tests/PlayMode/TransformObjectsManagerTest.cs
+++ b/Tests/PlayMode/TransformObjectsManagerTest.cs
@@ -36,11 +36,11 @@ public class TransformObjectsManagerTest : MonoBehaviour
         mockMediator = new MockMediator();
         transformObjectsManager.mediator = mockMediator;
         transformableObject0 = new GameObject("transformableObject0");
-        transformableObject0.AddComponent<ObjectTags>().AddTags(new ObjectTag[2] {ObjectTag.SELECTEABLE, ObjectTag.TRANSFORMABLE});
+        transformableObject0.AddComponent<ObjectTags>().AddTags(new ObjectTag[2] {ObjectTag.SELECTABLE, ObjectTag.TRANSFORMABLE});
         transformableObject1 = new GameObject("transformableObject1");
-        transformableObject1.AddComponent<ObjectTags>().AddTags(new ObjectTag[2] {ObjectTag.SELECTEABLE, ObjectTag.TRANSFORMABLE});
+        transformableObject1.AddComponent<ObjectTags>().AddTags(new ObjectTag[2] {ObjectTag.SELECTABLE, ObjectTag.TRANSFORMABLE});
         nonTransformableObject = new GameObject("nonTransformableObject");
-        nonTransformableObject.AddComponent<ObjectTags>().AddTags(new ObjectTag[1] {ObjectTag.SELECTEABLE});
+        nonTransformableObject.AddComponent<ObjectTags>().AddTags(new ObjectTag[1] {ObjectTag.SELECTABLE});
     }
 
     [UnityTest]

--- a/Tests/PlayMode/TransformObjectsManagerTest.cs
+++ b/Tests/PlayMode/TransformObjectsManagerTest.cs
@@ -9,6 +9,8 @@ using ReupVirtualTwin.enums;
 using ReupVirtualTwin.managerInterfaces;
 using ReupVirtualTwin.dataModels;
 using System;
+using ReupVirtualTwin.models;
+using ReupVirtualTwin.behaviours;
 
 public class TransformObjectsManagerTest : MonoBehaviour
 {
@@ -26,6 +28,7 @@ public class TransformObjectsManagerTest : MonoBehaviour
     {
         containerGameObject = new GameObject("containerGameObject");
         transformWrapper = new GameObject("transformWrapper");
+        containerGameObject.AddComponent<TagsHandler>();
         transformObjectsManager = containerGameObject.AddComponent<TransformObjectsManager>();
         runtimeTransformObj = new GameObject("TransformHandle");
         runtimeTransformObj.AddComponent<MockRuntimeTransformHandle>();
@@ -33,11 +36,11 @@ public class TransformObjectsManagerTest : MonoBehaviour
         mockMediator = new MockMediator();
         transformObjectsManager.mediator = mockMediator;
         transformableObject0 = new GameObject("transformableObject0");
-        transformableObject0.tag = TagsEnum.transformableObject;
+        transformableObject0.AddComponent<ObjectTags>().AddTags(new ObjectTag[2] {ObjectTag.SELECTEABLE, ObjectTag.TRANSFORMABLE});
         transformableObject1 = new GameObject("transformableObject1");
-        transformableObject1.tag = TagsEnum.transformableObject;
+        transformableObject1.AddComponent<ObjectTags>().AddTags(new ObjectTag[2] {ObjectTag.SELECTEABLE, ObjectTag.TRANSFORMABLE});
         nonTransformableObject = new GameObject("nonTransformableObject");
-        nonTransformableObject.tag = TagsEnum.selectableObject;
+        nonTransformableObject.AddComponent<ObjectTags>().AddTags(new ObjectTag[1] {ObjectTag.SELECTEABLE});
     }
 
     [UnityTest]
@@ -181,7 +184,6 @@ public class TransformObjectsManagerTest : MonoBehaviour
         };
         transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.RotationMode);
         yield return null;
-        Debug.Log("Asserting");
         Assert.IsFalse(transformObjectsManager.active);
         Assert.IsFalse(mockMediator.transformModeActive);
         yield return null;


### PR DESCRIPTION
[Reup183](https://macheight-reup.atlassian.net/browse/REUP-183?atlOrigin=eyJpIjoiZWZhOWU4YzFmMWQwNDlhMzliNmVjYTMxMmM4ZGIzMGMiLCJwIjoiaiJ9)

As a developer I want to have a system that allows me to add multiple tags to a gameobject so that I can classify and interact with them in a more organized way

AC:

Exits a script that can be attached to every gameobject and has a public list of usable tags

The tags are defined in an Enum class

the way to add tags to the gameobjects in a scene by the designer is with a button in the setUpBuilding gameobject

SelectedObjectsManager and TransformObjectsManager are updated to use the new Tag System.

EngineObject interface is not change.