### PR TITLE
Reup 142 Adding eyes gizmos 

### DIFF
--- a/Assets/Quickstart/Character.prefab
+++ b/Assets/Quickstart/Character.prefab
@@ -198,6 +198,7 @@ GameObject:
   - component: {fileID: 5955057430455588092}
   - component: {fileID: 4761280839834876021}
   - component: {fileID: 8847937629089256931}
+  - component: {fileID: 2154033466337776278}
   m_Layer: 7
   m_Name: left_eye
   m_TagString: Untagged
@@ -235,7 +236,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 16043791835660354}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -270,6 +271,18 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &2154033466337776278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16043791835660354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ead88295d35319f44a3cdf1227e50d0e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &59472179402601666
 GameObject:
   m_ObjectHideFlags: 0
@@ -279,8 +292,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2586828238354015427}
-  - component: {fileID: 6540381655027019359}
-  - component: {fileID: 7526764475329634063}
+  - component: {fileID: 9145431129484315031}
   m_Layer: 7
   m_Name: right_eye
   m_TagString: Untagged
@@ -303,56 +315,18 @@ Transform:
   m_Father: {fileID: 8424176746612216539}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &6540381655027019359
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 59472179402601666}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &7526764475329634063
-MeshRenderer:
+--- !u!114 &9145431129484315031
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 59472179402601666}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 6f10be99c51234e979f299c19540a1a8, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ead88295d35319f44a3cdf1227e50d0e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &151350736762601885
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/Utils.meta
+++ b/Runtime/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 39cdb83d2cc39094ebfc28587c5f9b35
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Utils/AddGizmo.cs
+++ b/Runtime/Utils/AddGizmo.cs
@@ -4,19 +4,7 @@ using UnityEngine;
 
 public class AddGizmo : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
-    private void OnDrawGizmos()
+      private void OnDrawGizmos()
     {
         Gizmos.color = Color.yellow;
         Gizmos.DrawSphere(transform.position, 0.05f);

--- a/Runtime/Utils/AddGizmo.cs
+++ b/Runtime/Utils/AddGizmo.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AddGizmo : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    private void OnDrawGizmos()
+    {
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawSphere(transform.position, 0.05f);
+    }
+}

--- a/Runtime/Utils/AddGizmo.cs.meta
+++ b/Runtime/Utils/AddGizmo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ead88295d35319f44a3cdf1227e50d0e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Utils/romulo.utils.asmdef
+++ b/Runtime/Utils/romulo.utils.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "reup.romulo.utils",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Runtime/Utils/romulo.utils.asmdef.meta
+++ b/Runtime/Utils/romulo.utils.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 319752e66e7f1c84f99b323e1df33c67
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
As a developer, I want to be able to see the eyes of the character when designing the project, but they should not render when running the scene. So I can easily know where is the front of the character when developing.

AC:

The character’s eyes are changed from spheres meshes to spheres gizmos that only render in the scene view, but not in the game view.

[https://macheight-reup.atlassian.net/jira/software/projects/REUP/boards/1?selectedIssue=REUP-142](url)