### PR TITLE
Fix Deactivate transform mode when no object is selected

### DIFF
--- a/Runtime/Managers/TransformObjectsManager.cs
+++ b/Runtime/Managers/TransformObjectsManager.cs
@@ -28,7 +28,7 @@ namespace ReupVirtualTwin.managers
         {
             set
             {
-                if (!AreWrappedObjectsTransformable(value.wrappedObjects))
+                if (value.wrapper == null || !AreWrappedObjectsTransformable(value.wrappedObjects))
                 {
                     DeactivateTransformMode();
                     return;
@@ -91,9 +91,8 @@ namespace ReupVirtualTwin.managers
 
         private bool AreWrappedObjectsTransformable(List<GameObject> objects)
         {
+            if (objects.Count == 0) return false;
             return objects.All(obj => _tagsController.DoesObjectHaveTag(obj, ObjectTag.TRANSFORMABLE));
         }
-
-
     }
 }

--- a/Tests/PlayMode/TransformObjectsManagerTest.cs
+++ b/Tests/PlayMode/TransformObjectsManagerTest.cs
@@ -51,7 +51,7 @@ public class TransformObjectsManagerTest : MonoBehaviour
         ObjectWrapperDTO objectWrapperDTO = new ObjectWrapperDTO()
         {
             wrapper = transformWrapper,
-            wrappedObjects = new List<GameObject>() { }
+            wrappedObjects = new List<GameObject>() {transformableObject0}
         };
         transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.PositionMode);
         Assert.AreEqual(TransformMode.PositionMode, mockMediator.mode);
@@ -70,7 +70,7 @@ public class TransformObjectsManagerTest : MonoBehaviour
         ObjectWrapperDTO objectWrapperDTO = new ObjectWrapperDTO()
         {
             wrapper = transformWrapper,
-            wrappedObjects = new List<GameObject>() { }
+            wrappedObjects = new List<GameObject>() {transformableObject0},
         };
         transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.RotationMode);
         Assert.AreEqual(TransformMode.RotationMode, mockMediator.mode);
@@ -89,7 +89,7 @@ public class TransformObjectsManagerTest : MonoBehaviour
         ObjectWrapperDTO objectWrapperDTO = new ObjectWrapperDTO()
         {
             wrapper = transformWrapper,
-            wrappedObjects = new List<GameObject>() { }
+            wrappedObjects = new List<GameObject>() { transformableObject0 },
         };
         transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.PositionMode);
         Assert.AreEqual(TransformMode.PositionMode, mockMediator.mode);
@@ -186,6 +186,50 @@ public class TransformObjectsManagerTest : MonoBehaviour
         yield return null;
         Assert.IsFalse(transformObjectsManager.active);
         Assert.IsFalse(mockMediator.transformModeActive);
+        yield return null;
+    }
+    [UnityTest]
+    public IEnumerator ShouldDeactivateTransformModeIfNoSelectedObject()
+    {
+        Assert.AreEqual(false, mockMediator.transformModeActive);
+        yield return null;
+        ObjectWrapperDTO objectWrapperDTO = new ObjectWrapperDTO()
+        {
+            wrapper = transformWrapper,
+            wrappedObjects = new List<GameObject>() {transformableObject0},
+        };
+        transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.PositionMode);
+        Assert.AreEqual(TransformMode.PositionMode, mockMediator.mode);
+        Assert.AreEqual(true, mockMediator.transformModeActive);
+        yield return null;
+        transformObjectsManager.wrapper = new ObjectWrapperDTO()
+        {
+            wrapper = transformWrapper,
+            wrappedObjects = new List<GameObject>() {},
+        };
+        Assert.AreEqual(false, mockMediator.transformModeActive);
+        yield return null;
+    }
+    [UnityTest]
+    public IEnumerator ShouldDeactivateTransformModeIfWrapperIsNull()
+    {
+        Assert.AreEqual(false, mockMediator.transformModeActive);
+        yield return null;
+        ObjectWrapperDTO objectWrapperDTO = new ObjectWrapperDTO()
+        {
+            wrapper = transformWrapper,
+            wrappedObjects = new List<GameObject>() {transformableObject0},
+        };
+        transformObjectsManager.ActivateTransformMode(objectWrapperDTO, TransformMode.PositionMode);
+        Assert.AreEqual(TransformMode.PositionMode, mockMediator.mode);
+        Assert.AreEqual(true, mockMediator.transformModeActive);
+        yield return null;
+        transformObjectsManager.wrapper = new ObjectWrapperDTO()
+        {
+            wrapper = null,
+            wrappedObjects = new List<GameObject>() { transformableObject0 },
+        };
+        Assert.AreEqual(false, mockMediator.transformModeActive);
         yield return null;
     }
 


### PR DESCRIPTION
Currently, when transform mode is active and all objects are deselected. An error occurs. This branch fix the bug