### PR TITLE
Reup 158 Allow keyboard input work outside of webgl

### DIFF
--- a/Assets/Quickstart/BaseGlobalScripts.prefab
+++ b/Assets/Quickstart/BaseGlobalScripts.prefab
@@ -490,8 +490,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: InputProviderStarter
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6121189262410777512, guid: 9f92a0f18388903468af853852dcb514, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 9f92a0f18388903468af853852dcb514, type: 3}
+--- !u!1 &6316950032361880468 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4355761033848208913, guid: 9f92a0f18388903468af853852dcb514, type: 3}
+  m_PrefabInstance: {fileID: 7771124988216657285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3876691237408315185
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6316950032361880468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42288d5dc7e86f54f907a2b2cd86fa6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &6316950032361880469 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4355761033848208912, guid: 9f92a0f18388903468af853852dcb514, type: 3}

--- a/Assets/ScriptHolders/InputProviderStarter.prefab
+++ b/Assets/ScriptHolders/InputProviderStarter.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4355761033848208912}
   - component: {fileID: 4355761033848208911}
+  - component: {fileID: 6121189262410777512}
   m_Layer: 0
   m_Name: InputProviderStarter
   m_TagString: Untagged
@@ -42,5 +43,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa3c3d3fd8c5450e8d15135c5359246, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6121189262410777512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4355761033848208913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42288d5dc7e86f54f907a2b2cd86fa6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Runtime/Inputs/SetUpWebglInput.cs
+++ b/Runtime/Inputs/SetUpWebglInput.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SetUpWebglInput : MonoBehaviour
+{
+    void Start()
+    {
+#if !UNITY_EDITOR && UNITY_WEBGL
+                  WebGLInput.captureAllKeyboardInput = false;
+#endif  
+
+    }
+
+}

--- a/Runtime/Inputs/SetUpWebglInput.cs.meta
+++ b/Runtime/Inputs/SetUpWebglInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42288d5dc7e86f54f907a2b2cd86fa6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Description

As a user, I want to be able to use my keyboard outside of the model while still playing the DT. So I can still interact with the DT website.

AC:

When using asdw keys the character doesn’t move if the canvas is not selected.

It’s possible to write text in the website while playing a DT. for example a text input

The option captureAllKeyboardInput was set to false so now the inputs are not being sent to unity while not on focus

