### PR TITLE
REUP-237 Fix CharacterColliderBoxController it's a monobehaviour but it's being created with new

### DIFF
--- a/Runtime/Controllers/CharacterColliderBoxController.cs
+++ b/Runtime/Controllers/CharacterColliderBoxController.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace ReupVirtualTwin.controllers
 {
-    public class CharacterColliderBoxController : MonoBehaviour, ICharacterColliderController
+    public class CharacterColliderBoxController : ICharacterColliderController
 
     {
         GameObject character;
@@ -33,7 +33,7 @@ namespace ReupVirtualTwin.controllers
             Collider collider = character.GetComponent<Collider>();
             if (collider != null)
             {
-                Destroy(collider);
+                GameObject.Destroy(collider);
             }
         }
 


### PR DESCRIPTION
[REUP-237](https://macheight-reup.atlassian.net/browse/REUP-237)

Delete the MonoBehaviour inheritance from the CharacterColliderBoxController and update the DestroyCollider() method as it was using the Destroy() method from the MonoBehaviourr inheritance.


As a developer, I want to avoid any controller from inheriting from monobehaviour, so the model build is smaller and runs more smoothly

AC:

CharacterColliderBoxController should not inherit from monobehaviour
CharacterColliderBoxController Should be created using the keyword new

Notes:
Controllers are scripts that are not attached to a gameobject, so they don't need to be monobehaviours