### PR TITLE
Reup 248 fix incomplete teardown in some test

### DIFF
--- a/Tests/PlayMode/IdControllerTest.cs
+++ b/Tests/PlayMode/IdControllerTest.cs
@@ -37,6 +37,7 @@ namespace ReupVirtualTwinTests.Registry
             child1.transform.parent = parent.transform;
             grandchild00.transform.parent = child0.transform;
         }
+
         [TearDown]
         public void TearDown()
         {

--- a/Tests/PlayMode/IdControllerTest.cs
+++ b/Tests/PlayMode/IdControllerTest.cs
@@ -37,20 +37,15 @@ namespace ReupVirtualTwinTests.Registry
             child1.transform.parent = parent.transform;
             grandchild00.transform.parent = child0.transform;
         }
-
-        [TearDown]
-        public void TearDown()
+        
+        [UnityTearDown]
+        public IEnumerator TearDownCoroutine()
         {
             Destroy(parent);
             Destroy(child0);
             Destroy(child1);
             Destroy(grandchild00);
             Destroy(objectRegistryGameObject);
-        }
-        
-        [UnityTearDown]
-        public IEnumerator TearDownCoroutine()
-        {
             yield return new WaitForSeconds(0.2f);
         }
 

--- a/Tests/PlayMode/IdControllerTest.cs
+++ b/Tests/PlayMode/IdControllerTest.cs
@@ -22,18 +22,12 @@ namespace ReupVirtualTwinTests.Registry
         GameObject grandchild00;
         IdController idController;
 
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            // we set the objectRegistry only once because some objects that depend on it are use the ObjectFinder class to find it
-            // if we create a different objectRegistry for each test in the SetUp method, the ObjectFinder sometimes finds
-            // an old objectRegistry why this happens is still unknown to me
-            objectRegistryGameObject = (GameObject)PrefabUtility.InstantiatePrefab(ObjectRegistryPrefab);
-            objectRegistry = objectRegistryGameObject.GetComponent<IRegistry>();
-        }
         [SetUp]
         public void SetUp()
         {
+            objectRegistryGameObject = (GameObject)PrefabUtility.InstantiatePrefab(ObjectRegistryPrefab);
+            objectRegistry = objectRegistryGameObject.GetComponent<IRegistry>();
+
             idController = new IdController();
             parent = new GameObject("testObj1");
             child0 = new GameObject("testObj1");
@@ -50,10 +44,6 @@ namespace ReupVirtualTwinTests.Registry
             Destroy(child0);
             Destroy(child1);
             Destroy(grandchild00);
-        }
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
             Destroy(objectRegistryGameObject);
         }
 

--- a/Tests/PlayMode/IdControllerTest.cs
+++ b/Tests/PlayMode/IdControllerTest.cs
@@ -47,6 +47,12 @@ namespace ReupVirtualTwinTests.Registry
             Destroy(grandchild00);
             Destroy(objectRegistryGameObject);
         }
+        
+        [UnityTearDown]
+        public IEnumerator TearDownCoroutine()
+        {
+            yield return new WaitForSeconds(0.2f);
+        }
 
         [UnityTest]
         public IEnumerator ShouldAssignARegisteredIdentifier()

--- a/Tests/PlayMode/ObjectRegistryTests.cs
+++ b/Tests/PlayMode/ObjectRegistryTests.cs
@@ -23,18 +23,13 @@ namespace ReupVirtualTwinTests.Registry
             objectRegistry = objectRegistryGameObject.GetComponent<IRegistry>();
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDownCoroutine()
         {
             Destroy(testObj0);
             Destroy(testObj1);
             objectRegistry.ClearRegistry();
             Destroy(objectRegistryGameObject);
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDownCoroutine()
-        {
             yield return new WaitForSeconds(0.2f);
         }
 

--- a/Tests/PlayMode/ObjectRegistryTests.cs
+++ b/Tests/PlayMode/ObjectRegistryTests.cs
@@ -16,12 +16,9 @@ namespace ReupVirtualTwinTests.Registry
         GameObject testObj0;
         GameObject testObj1;
 
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
+        [SetUp]
+        public void SetUp()
         {
-            // we set the objectRegistry only once because some objects that depend on it are use the ObjectFinder class to find it
-            // if we create a different objectRegistry for each test in the SetUp method, the ObjectFinder sometimes finds
-            // an old objectRegistry why this happens is still unknown to me
             objectRegistryGameObject = (GameObject)PrefabUtility.InstantiatePrefab(ObjectRegistryPrefab);
             objectRegistry = objectRegistryGameObject.GetComponent<IRegistry>();
         }
@@ -32,11 +29,6 @@ namespace ReupVirtualTwinTests.Registry
             Destroy(testObj0);
             Destroy(testObj1);
             objectRegistry.ClearRegistry();
-        }
-
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
             Destroy(objectRegistryGameObject);
         }
 

--- a/Tests/PlayMode/ObjectRegistryTests.cs
+++ b/Tests/PlayMode/ObjectRegistryTests.cs
@@ -32,6 +32,12 @@ namespace ReupVirtualTwinTests.Registry
             Destroy(objectRegistryGameObject);
         }
 
+        [UnityTearDown]
+        public IEnumerator TearDownCoroutine()
+        {
+            yield return new WaitForSeconds(0.2f);
+        }
+
         [UnityTest]
         public IEnumerator ShouldAddAnItemToRegistry()
         {

--- a/Tests/PlayMode/RegisteredIdentifierTest.cs
+++ b/Tests/PlayMode/RegisteredIdentifierTest.cs
@@ -53,7 +53,6 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator NoObjectIsReturnedIfIncorrectId()
         {
-            
             var obtainedObj = objectRegistry.GetItemWithGuid("an-incorrect-id");
             Assert.IsNull(obtainedObj);
             yield return null;
@@ -61,7 +60,7 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ObjectIsRegistryIsUpdatedIfNewIdIsAssigned()
         {
-            var currentId = testObj.GetComponent<RegisteredIdentifier>().getId();
+            string currentId = testObj.GetComponent<RegisteredIdentifier>().getId();
             Assert.AreEqual(testObj, objectRegistry.GetItemWithGuid(currentId));
             Assert.AreEqual(1, objectRegistry.GetItemCount());
             string newId = "new-id";

--- a/Tests/PlayMode/RegisteredIdentifierTest.cs
+++ b/Tests/PlayMode/RegisteredIdentifierTest.cs
@@ -4,6 +4,8 @@ using ReupVirtualTwin.models;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
+using System.Collections;
+using ReupVirtualTwin.modelInterfaces;
 
 namespace ReupVirtualTwinTests.Registry
 {
@@ -14,18 +16,11 @@ namespace ReupVirtualTwinTests.Registry
         IRegistry objectRegistry;
         GameObject testObj;
 
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            // we set the objectRegistry only once because some objects that depend on it are use the ObjectFinder class to find it
-            // if we create a different objectRegistry for each test in the SetUp method, the ObjectFinder sometimes finds
-            // an old objectRegistry why this happens is still unknown to me
-            objectRegistryGameObject = (GameObject)PrefabUtility.InstantiatePrefab(ObjectRegistryPrefab);
-            objectRegistry = objectRegistryGameObject.GetComponent<IRegistry>();
-        }
         [SetUp]
         public void SetUp()
         {
+            objectRegistryGameObject = (GameObject)PrefabUtility.InstantiatePrefab(ObjectRegistryPrefab);
+            objectRegistry = objectRegistryGameObject.GetComponent<IRegistry>();
             testObj = new GameObject("testObj");
             testObj.AddComponent<RegisteredIdentifier>();
         }
@@ -34,16 +29,13 @@ namespace ReupVirtualTwinTests.Registry
         {
             Destroy(testObj);
             objectRegistry.ClearRegistry();
-        }
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
             Destroy(objectRegistryGameObject);
         }
 
         [UnityTest]
         public IEnumerator TestObjHasAnId()
         {
+            yield return new WaitForSeconds(0.2f);
             var id = testObj.GetComponent<RegisteredIdentifier>().getId();
             Assert.IsNotNull(id);
             yield return null;
@@ -52,6 +44,7 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ObjectRegistryContainsTestObj()
         {
+            yield return new WaitForSeconds(0.2f);
             var id = testObj.GetComponent<RegisteredIdentifier>().getId();
             var obtainedObj = objectRegistry.GetItemWithGuid(id);
             Assert.AreEqual(testObj, obtainedObj);
@@ -61,6 +54,7 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator NoObjectIsReturnedIfIncorrectId()
         {
+            yield return new WaitForSeconds(0.2f);
             var obtainedObj = objectRegistry.GetItemWithGuid("an-incorrect-id");
             Assert.IsNull(obtainedObj);
             yield return null;
@@ -68,7 +62,8 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ObjectIsRegistryIsUpdatedIfNewIdIsAssigned()
         {
-            string currentId = testObj.GetComponent<RegisteredIdentifier>().getId();
+            yield return new WaitForSeconds(0.2f);
+            var currentId = testObj.GetComponent<RegisteredIdentifier>().getId();
             Assert.AreEqual(testObj, objectRegistry.GetItemWithGuid(currentId));
             Assert.AreEqual(1, objectRegistry.GetItemCount());
             string newId = "new-id";
@@ -82,6 +77,7 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ShoulBeAbleToGenerateIdRightAfterCreatingTheUniqueIdComponent()
         {
+            yield return new WaitForSeconds(0.2f);
             GameObject gameObject = new GameObject("new-game-obj");
             RegisteredIdentifier registeredIdentifier = gameObject.AddComponent<RegisteredIdentifier>();
             registeredIdentifier.GenerateId();
@@ -92,6 +88,7 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ShoulBeAbleToAssignIdRightAfterCreatingTheUniqueIdComponent()
         {
+            yield return new WaitForSeconds(0.2f);
             GameObject gameObject = new GameObject("new-game-obj");
             RegisteredIdentifier registeredIdentifier = gameObject.AddComponent<RegisteredIdentifier>();
             string assignedId = "assigned-id";

--- a/Tests/PlayMode/RegisteredIdentifierTest.cs
+++ b/Tests/PlayMode/RegisteredIdentifierTest.cs
@@ -24,18 +24,12 @@ namespace ReupVirtualTwinTests.Registry
             testObj.AddComponent<RegisteredIdentifier>();
         }
 
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDownCoroutine()
         {
             Destroy(testObj);
             objectRegistry.ClearRegistry();
             Destroy(objectRegistryGameObject);
-
-        }
-
-        [UnityTearDown]
-        public IEnumerator TearDownCoroutine()
-        {
             yield return new WaitForSeconds(0.2f);
         }
 

--- a/Tests/PlayMode/RegisteredIdentifierTest.cs
+++ b/Tests/PlayMode/RegisteredIdentifierTest.cs
@@ -4,7 +4,6 @@ using ReupVirtualTwin.models;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
-using System.Collections;
 using ReupVirtualTwin.modelInterfaces;
 
 namespace ReupVirtualTwinTests.Registry
@@ -24,18 +23,25 @@ namespace ReupVirtualTwinTests.Registry
             testObj = new GameObject("testObj");
             testObj.AddComponent<RegisteredIdentifier>();
         }
+
         [TearDown]
         public void TearDown()
         {
             Destroy(testObj);
             objectRegistry.ClearRegistry();
             Destroy(objectRegistryGameObject);
+
+        }
+
+        [UnityTearDown]
+        public IEnumerator TearDownCoroutine()
+        {
+            yield return new WaitForSeconds(0.2f);
         }
 
         [UnityTest]
         public IEnumerator TestObjHasAnId()
         {
-            yield return new WaitForSeconds(0.2f);
             var id = testObj.GetComponent<RegisteredIdentifier>().getId();
             Assert.IsNotNull(id);
             yield return null;
@@ -44,7 +50,6 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ObjectRegistryContainsTestObj()
         {
-            yield return new WaitForSeconds(0.2f);
             var id = testObj.GetComponent<RegisteredIdentifier>().getId();
             var obtainedObj = objectRegistry.GetItemWithGuid(id);
             Assert.AreEqual(testObj, obtainedObj);
@@ -54,7 +59,7 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator NoObjectIsReturnedIfIncorrectId()
         {
-            yield return new WaitForSeconds(0.2f);
+            
             var obtainedObj = objectRegistry.GetItemWithGuid("an-incorrect-id");
             Assert.IsNull(obtainedObj);
             yield return null;
@@ -62,7 +67,6 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ObjectIsRegistryIsUpdatedIfNewIdIsAssigned()
         {
-            yield return new WaitForSeconds(0.2f);
             var currentId = testObj.GetComponent<RegisteredIdentifier>().getId();
             Assert.AreEqual(testObj, objectRegistry.GetItemWithGuid(currentId));
             Assert.AreEqual(1, objectRegistry.GetItemCount());
@@ -77,7 +81,6 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ShoulBeAbleToGenerateIdRightAfterCreatingTheUniqueIdComponent()
         {
-            yield return new WaitForSeconds(0.2f);
             GameObject gameObject = new GameObject("new-game-obj");
             RegisteredIdentifier registeredIdentifier = gameObject.AddComponent<RegisteredIdentifier>();
             registeredIdentifier.GenerateId();
@@ -88,7 +91,6 @@ namespace ReupVirtualTwinTests.Registry
         [UnityTest]
         public IEnumerator ShoulBeAbleToAssignIdRightAfterCreatingTheUniqueIdComponent()
         {
-            yield return new WaitForSeconds(0.2f);
             GameObject gameObject = new GameObject("new-game-obj");
             RegisteredIdentifier registeredIdentifier = gameObject.AddComponent<RegisteredIdentifier>();
             string assignedId = "assigned-id";


### PR DESCRIPTION
[REUP-248](https://macheight-reup.atlassian.net/browse/REUP-248)

Modifies the setup and teardown methods of the IdControllerTest, ObjectRegistryTest and RegisteredIdentifierTest.

Ensures that the objectRegistryGameObject is created and deleted before and after each test, taking care of the asynchronous operations that were generating errors by not executing before the assersts.

As a developer, I want to completely teardown the game objects from the tests, so I can properly avoid tests from having effect in other tests

AC:

The `objectRegistryGameObject` is destroyed in the following tests:

    -IdControllerTest

    -ObjectRegistryTests

    -RegisteredIdentifierTest

All tests should still be working, and every test has to have a new `objectRegistryGameObject` instance