### PR TITLE
REUP-243 overlay of keyboard control - Change the Input movement keys

### DIFF
--- a/Runtime/Inputs/AppInputActions.cs
+++ b/Runtime/Inputs/AppInputActions.cs
@@ -148,6 +148,39 @@ public partial class @AppInputActions: IInputActionCollection2, IDisposable
                     ""isPartOfComposite"": false
                 },
                 {
+                    ""name"": ""arrows"",
+                    ""id"": ""f1f16253-6b30-4fcf-a8a3-0557c1fbedf2"",
+                    ""path"": ""2DVector"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Movement"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""up"",
+                    ""id"": ""a98335bb-a8ae-49b8-9ab8-20fda96fb615"",
+                    ""path"": ""<Keyboard>/upArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""KeyboardAndMouse"",
+                    ""action"": ""Movement"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""down"",
+                    ""id"": ""2f3d1af1-6995-434d-bf48-3bcfa566489d"",
+                    ""path"": ""<Keyboard>/downArrow"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""KeyboardAndMouse"",
+                    ""action"": ""Movement"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
                     ""name"": ""wasd"",
                     ""id"": ""d111dde3-9997-4806-bbb6-70824107c680"",
                     ""path"": ""2DVector"",
@@ -161,6 +194,17 @@ public partial class @AppInputActions: IInputActionCollection2, IDisposable
                 {
                     ""name"": ""up"",
                     ""id"": ""7d338a69-a683-453c-a9d3-db6d53786159"",
+                    ""path"": ""<Mouse>/scroll/up"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""KeyboardAndMouse"",
+                    ""action"": ""Movement"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""up"",
+                    ""id"": ""6933eb39-19a2-47e6-a606-1d96d3bd3e01"",
                     ""path"": ""<Keyboard>/w"",
                     ""interactions"": """",
                     ""processors"": """",
@@ -173,6 +217,17 @@ public partial class @AppInputActions: IInputActionCollection2, IDisposable
                     ""name"": ""down"",
                     ""id"": ""805eff14-9233-41a3-91c3-e2037ec14a8c"",
                     ""path"": ""<Keyboard>/s"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""KeyboardAndMouse"",
+                    ""action"": ""Movement"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""down"",
+                    ""id"": ""ee0cef53-16b1-42eb-ab9e-cc9ee4f50ccd"",
+                    ""path"": ""<Mouse>/scroll/down"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""KeyboardAndMouse"",
@@ -267,28 +322,6 @@ public partial class @AppInputActions: IInputActionCollection2, IDisposable
                     ""action"": ""RotateViewKeyborad"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": ""up"",
-                    ""id"": ""58d5b28e-3a39-457a-89d6-de2ba67bafd4"",
-                    ""path"": ""<Keyboard>/upArrow"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""KeyboardAndMouse"",
-                    ""action"": ""RotateViewKeyborad"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
-                },
-                {
-                    ""name"": ""down"",
-                    ""id"": ""59e39523-07e2-4e29-9a72-8813c273c098"",
-                    ""path"": ""<Keyboard>/downArrow"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""KeyboardAndMouse"",
-                    ""action"": ""RotateViewKeyborad"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
                 },
                 {
                     ""name"": ""left"",

--- a/Runtime/Inputs/AppInputActions.inputactions
+++ b/Runtime/Inputs/AppInputActions.inputactions
@@ -126,6 +126,39 @@
                     "isPartOfComposite": false
                 },
                 {
+                    "name": "arrows",
+                    "id": "f1f16253-6b30-4fcf-a8a3-0557c1fbedf2",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Movement",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "a98335bb-a8ae-49b8-9ab8-20fda96fb615",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardAndMouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "2f3d1af1-6995-434d-bf48-3bcfa566489d",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardAndMouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
                     "name": "wasd",
                     "id": "d111dde3-9997-4806-bbb6-70824107c680",
                     "path": "2DVector",
@@ -139,6 +172,17 @@
                 {
                     "name": "up",
                     "id": "7d338a69-a683-453c-a9d3-db6d53786159",
+                    "path": "<Mouse>/scroll/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardAndMouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "6933eb39-19a2-47e6-a606-1d96d3bd3e01",
                     "path": "<Keyboard>/w",
                     "interactions": "",
                     "processors": "",
@@ -151,6 +195,17 @@
                     "name": "down",
                     "id": "805eff14-9233-41a3-91c3-e2037ec14a8c",
                     "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardAndMouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "ee0cef53-16b1-42eb-ab9e-cc9ee4f50ccd",
+                    "path": "<Mouse>/scroll/down",
                     "interactions": "",
                     "processors": "",
                     "groups": "KeyboardAndMouse",
@@ -245,28 +300,6 @@
                     "action": "RotateViewKeyborad",
                     "isComposite": true,
                     "isPartOfComposite": false
-                },
-                {
-                    "name": "up",
-                    "id": "58d5b28e-3a39-457a-89d6-de2ba67bafd4",
-                    "path": "<Keyboard>/upArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardAndMouse",
-                    "action": "RotateViewKeyborad",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "down",
-                    "id": "59e39523-07e2-4e29-9a72-8813c273c098",
-                    "path": "<Keyboard>/downArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "KeyboardAndMouse",
-                    "action": "RotateViewKeyborad",
-                    "isComposite": false,
-                    "isPartOfComposite": true
                 },
                 {
                     "name": "left",


### PR DESCRIPTION
[REUP-243](https://macheight-reup.atlassian.net/browse/REUP-243)

Change the movement keys

The user can walk straight with the up and down arrow keys. 
The user can rotate the view with the left and right arrow keys. 
The user can walk straight and sideways with the WASD keys. 
No other movement keys are affected.