### PR TITLE
Change action tags

### DIFF
--- a/Runtime/Enums/EditionTag.cs
+++ b/Runtime/Enums/EditionTag.cs
@@ -1,9 +1,9 @@
 namespace ReupVirtualTwin.enums
 {
-    public enum EditionTag
+    public static class EditionTag
     {
-        SELECTABLE,
-        TRANSFORMABLE,
-        DELETABLE,
+        public static readonly string SELECTABLE = "[action] selectable";
+        public static readonly string TRANSFORMABLE = "[action] transformable";
+        public static readonly string DELETABLE = "[action] deletable";
     }
 }


### PR DESCRIPTION
[Reup262](https://macheight-reup.atlassian.net/browse/REUP-262?atlOrigin=eyJpIjoiMjJiYjk0Njc0NTQ0NGFkMzkzNWFhOGI2NWZkNTI1YTAiLCJwIjoiaiJ9)

As a developer, I want to have predefined tags types in the django admin so I can’t make mistakes when defining a tag regarding its type

AC:

The Tag model has a new column called tag_type with the following types

“location”

“object_type”

User may specify the tag name and tag type in the admin interface

The REST endpoint will concatenate the type and the name of the tag when returning the tags. For example

[location] Living Room

[object_type] Chair

All existing tags in the database are migrated to separate the tag type from the tag name

If any existing tags don’t match the pattern of [tag type] tag name where tag type is one of location or object_type, an error is thrown on migration

The action type tags in unity are updated to follow the form [action] selectable

Front end code that looks at action type tags are backwards compatible with tags that do or don’t have the [action] prefix